### PR TITLE
Add Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ members = ["libgphoto2-sys"]
 
 [dependencies]
 libgphoto2_sys = { path = "libgphoto2-sys", version = "1.0.1" }
+
+[target.'cfg(windows)'.dependencies]
+libc = "0.2"

--- a/libgphoto2-sys/src/build.rs
+++ b/libgphoto2-sys/src/build.rs
@@ -2,12 +2,13 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-  pkg_config::Config::new()
+  let lib = pkg_config::Config::new()
     .atleast_version("2.5.10")
     .probe("libgphoto2")
     .expect("Could not find libgphoto2");
 
   let bindings = bindgen::Builder::default()
+    .clang_args(lib.include_paths.iter().map(|path| format!("-I{}", path.to_string_lossy())))
     .header("src/wrapper.h")
     .generate_comments(true)
     .parse_callbacks(Box::new(bindgen::CargoCallbacks))


### PR DESCRIPTION
This makes it possible to use gphoto2-rs on Windows (at least with libgphoto2-sys package in MSYS2 environment).