### PR TITLE
Fix segfault in StorageInfo Drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,4 @@ members = ["libgphoto2-sys"]
 
 [dependencies]
 libgphoto2_sys = { path = "libgphoto2-sys", version = "1.0.1" }
-
-[target.'cfg(windows)'.dependencies]
 libc = "0.2"

--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -68,6 +68,8 @@ pub enum AccessType {
 }
 
 /// Information about a storage on the camera
+#[repr(transparent)]
+#[derive(Clone, Copy)]
 pub struct StorageInfo {
   pub(crate) inner: libgphoto2_sys::CameraStorageInformation,
 }
@@ -274,10 +276,6 @@ impl FilePermissions {
 }
 
 impl StorageInfo {
-  pub(crate) fn new(info: libgphoto2_sys::CameraStorageInformation) -> Self {
-    Self { inner: info }
-  }
-
   /// Base directory of the storage. If there is only 1 storage on the camera it will be "/"
   pub fn base_directory(&self) -> Option<Cow<str>> {
     if storage_has_ability!(self.inner, GP_STORAGEINFO_BASE) {


### PR DESCRIPTION
`Vec::from_raw_parts` requires the input pointer to be allocated using Rust allocators (e.g. via `Box` or `Vec`), as it will attempt to free the result using Rust allocators as well.

Previously, this code passed libc-allocated pointers as-is to `Vec::from_raw_parts`. When Rust allocator != libc allocator, e.g. on Windows, or if custom allocator is used via `#[global_allocator]`, this caused heap corruption errors when `Vec` tried to deallocate itself during `Drop` phase:

```
...
        "Universal Serial Bus",
    ),
    path: Some(
        "usb:002,015",
    ),
    port_type: Some(
        Usb,
    ),
}
error: process didn't exit successfully: `target\debug\examples\camera_info.exe` (exit code: 0xc0000374, STATUS_HEAP_CORRUPTION)
```

After this change, the original pointer will be always freed using `libc::free` and the error is gone.