### PR TITLE
Fix the way `MaybeUninit` is used

### DIFF
--- a/examples/list_config.rs
+++ b/examples/list_config.rs
@@ -17,7 +17,7 @@ fn display_widget_recursive(widget: &Widget, prefix: &str) -> Result<()> {
     println!("VALUE: {:?}", value)
   }
 
-  print!("\n");
+  println!();
 
   for child in widget.children_iter()? {
     display_widget_recursive(&child, &new_prefix)?;

--- a/src/abilities.rs
+++ b/src/abilities.rs
@@ -2,11 +2,7 @@
 //!
 //! The device abilities describe the abilities of the driver used to connect to a device.
 
-use crate::{
-  context::Context,
-  helper::{chars_to_cow, uninit},
-  try_gp_internal, Inner, InnerPtr, Result,
-};
+use crate::{context::Context, helper::chars_to_cow, try_gp_internal, Inner, InnerPtr, Result};
 use std::{borrow::Cow, ffi, fmt, marker::PhantomData, os::raw::c_int};
 
 pub(crate) struct AbilitiesList<'a> {
@@ -163,10 +159,8 @@ impl<'a> Inner<'a, libgphoto2_sys::CameraAbilities> for Abilities {
 
 impl<'a> AbilitiesList<'a> {
   pub(crate) fn new(context: &Context) -> Result<Self> {
-    let mut abilities_inner = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_abilities_list_new(&mut abilities_inner))?;
-    try_gp_internal!(libgphoto2_sys::gp_abilities_list_load(abilities_inner, context.inner))?;
+    try_gp_internal!(gp_abilities_list_new(&out abilities_inner));
+    try_gp_internal!(gp_abilities_list_load(abilities_inner, context.inner));
 
     Ok(Self { inner: abilities_inner, _phantom: PhantomData })
   }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -4,7 +4,7 @@ use crate::{
   abilities::Abilities,
   file::{CameraFile, CameraFilePath},
   filesys::{CameraFS, StorageInfo},
-  helper::{camera_text_to_str, chars_to_cow, uninit},
+  helper::{camera_text_to_str, chars_to_cow, to_c_string},
   port::PortInfo,
   try_gp_internal,
   widget::{Widget, WidgetType},
@@ -106,14 +106,12 @@ impl<'a> Camera<'a> {
 
   /// Capture image
   pub fn capture_image(&self) -> Result<CameraFilePath> {
-    let mut file_path_ptr = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_capture(
+    try_gp_internal!(gp_camera_capture(
       self.camera,
       libgphoto2_sys::CameraCaptureType::GP_CAPTURE_IMAGE,
-      &mut file_path_ptr,
+      &out file_path_ptr,
       self.context.inner
-    ))?;
+    ));
 
     Ok(file_path_ptr.into())
   }
@@ -135,11 +133,7 @@ impl<'a> Camera<'a> {
   pub fn capture_preview(&self) -> Result<CameraFile> {
     let camera_file = CameraFile::new()?;
 
-    try_gp_internal!(libgphoto2_sys::gp_camera_capture_preview(
-      self.camera,
-      camera_file.inner,
-      self.context.inner
-    ))?;
+    try_gp_internal!(gp_camera_capture_preview(self.camera, camera_file.inner, self.context.inner));
 
     Ok(camera_file)
   }
@@ -148,35 +142,21 @@ impl<'a> Camera<'a> {
   ///
   /// The abilities contain information about the driver used, permissions and camera model
   pub fn abilities(&self) -> Result<Abilities> {
-    let mut abilities = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_get_abilities(self.camera, &mut abilities))?;
+    try_gp_internal!(gp_camera_get_abilities(self.camera, &out abilities));
 
     Ok(abilities.into())
   }
 
   /// Summary of the cameras model, settings, capabilities, etc.
   pub fn summary(&self) -> Result<Cow<str>> {
-    let mut summary = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_get_summary(
-      self.camera,
-      &mut summary,
-      self.context.inner
-    ))?;
+    try_gp_internal!(gp_camera_get_summary(self.camera, &out summary, self.context.inner));
 
     Ok(camera_text_to_str(summary))
   }
 
   /// Get about information about the camera#
   pub fn about(&self) -> Result<Cow<str>> {
-    let mut about = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_get_about(
-      self.camera,
-      &mut about,
-      self.context.inner
-    ))?;
+    try_gp_internal!(gp_camera_get_about(self.camera, &out about, self.context.inner));
 
     Ok(camera_text_to_str(about))
   }
@@ -185,28 +165,19 @@ impl<'a> Camera<'a> {
   ///
   /// Not all cameras support this, and will return NotSupported
   pub fn manual(&self) -> Result<Cow<str>> {
-    let mut manual = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_get_manual(
-      self.camera,
-      &mut manual,
-      self.context.inner
-    ))?;
+    try_gp_internal!(gp_camera_get_manual(self.camera, &out manual, self.context.inner));
 
     Ok(camera_text_to_str(manual))
   }
 
   /// List of storages available on the camera
   pub fn storages(&self) -> Result<Vec<StorageInfo>> {
-    let mut storages_ptr = unsafe { uninit() };
-    let mut storages_len = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_get_storageinfo(
+    try_gp_internal!(gp_camera_get_storageinfo(
       self.camera,
-      &mut storages_ptr,
-      &mut storages_len,
+      &out storages_ptr,
+      &out storages_len,
       self.context.inner
-    ))?;
+    ));
 
     Ok(
       unsafe { Vec::from_raw_parts(storages_ptr, storages_len as usize, storages_len as usize) }
@@ -227,16 +198,13 @@ impl<'a> Camera<'a> {
 
     let duration_milliseconds = timeout.as_millis();
 
-    let mut event_type = unsafe { uninit() };
-    let mut event_data = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_wait_for_event(
+    try_gp_internal!(gp_camera_wait_for_event(
       self.camera,
       duration_milliseconds as i32,
-      &mut event_type,
-      &mut event_data,
+      &out event_type,
+      &out event_data,
       self.context.inner
-    ))?;
+    ));
 
     Ok(match event_type {
       CameraEventType::GP_EVENT_UNKNOWN => {
@@ -262,38 +230,26 @@ impl<'a> Camera<'a> {
 
   /// Port used to connect to the camera
   pub fn port_info(&self) -> Result<PortInfo> {
-    let mut port_info = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_get_port_info(self.camera, &mut port_info))?;
+    try_gp_internal!(gp_camera_get_port_info(self.camera, &out port_info));
 
     Ok(PortInfo { inner: port_info })
   }
 
   /// Get the camera configuration
   pub fn config(&self) -> Result<Widget<'a>> {
-    let mut root_widget = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_get_config(
-      self.camera,
-      &mut root_widget,
-      self.context.inner
-    ))?;
+    try_gp_internal!(gp_camera_get_config(self.camera, &out root_widget, self.context.inner));
 
     Ok(Widget::new(root_widget))
   }
 
   /// Get a single configuration by name
   pub fn config_key(&self, key: &str) -> Result<Widget<'a>> {
-    let mut widget = unsafe { uninit() };
-
-    let key = ffi::CString::new(key)?;
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_get_single_config(
+    try_gp_internal!(gp_camera_get_single_config(
       self.camera,
-      key.as_ptr() as *const c_char,
-      &mut widget,
+      to_c_string!(key),
+      &out widget,
       self.context.inner
-    ))?;
+    ));
 
     Ok(Widget::new(widget))
   }
@@ -306,25 +262,19 @@ impl<'a> Camera<'a> {
       Err("Full config object must be of type Window or section")?;
     }
 
-    try_gp_internal!(libgphoto2_sys::gp_camera_set_config(
-      self.camera,
-      config.inner,
-      self.context.inner
-    ))?;
+    try_gp_internal!(gp_camera_set_config(self.camera, config.inner, self.context.inner));
 
     Ok(())
   }
 
   /// Set a single configuration widget to the camera
   pub fn set_config(&self, config: &Widget) -> Result<()> {
-    let name = ffi::CString::new(&config.name()?[..])?;
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_set_single_config(
+    try_gp_internal!(gp_camera_set_single_config(
       self.camera,
-      name.as_ptr() as *const c_char,
+      to_c_string!(config.name()?.as_ref()),
       config.inner,
       self.context.inner
-    ))?;
+    ));
 
     Ok(())
   }

--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -2,15 +2,11 @@
 
 use crate::{
   file::{CameraFile, FileType},
-  helper::{chars_to_cow, to_c_string, uninit},
+  helper::{chars_to_cow, to_c_string},
   list::CameraList,
   try_gp_internal, Camera, Result,
 };
-use std::{
-  borrow::Cow,
-  ffi, fmt,
-  os::raw::{c_char, c_int},
-};
+use std::{borrow::Cow, ffi, fmt, os::raw::c_int};
 
 macro_rules! storage_has_ability {
   ($inf:expr, $it:ident) => {
@@ -367,62 +363,49 @@ impl<'a> CameraFS<'a> {
 
   /// Delete a file
   pub fn delete_file(&self, folder: &str, file: &str) -> Result<()> {
-    to_c_string!(folder, folder);
-    to_c_string!(file, file);
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_file_delete(
+    try_gp_internal!(gp_camera_file_delete(
       self.camera.camera,
-      folder.as_ptr() as *const c_char,
-      file.as_ptr() as *const c_char,
+      to_c_string!(folder),
+      to_c_string!(file),
       self.camera.context.inner
-    ))?;
+    ));
     Ok(())
   }
 
   /// Get information of a file
   pub fn info(&self, folder: &str, file: &str) -> Result<FileInfo> {
-    let mut file_info = unsafe { uninit() };
-
-    to_c_string!(folder);
-    to_c_string!(file);
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_file_get_info(
+    try_gp_internal!(gp_camera_file_get_info(
       self.camera.camera,
-      folder.as_ptr() as *const c_char,
-      file.as_ptr() as *const c_char,
-      &mut file_info,
+      to_c_string!(folder),
+      to_c_string!(file),
+      &out file_info,
       self.camera.context.inner
-    ))?;
+    ));
 
     Ok(file_info.into())
   }
 
   /// Upload a file to the camera
   pub fn upload_file(&self, folder: &str, filename: &str, file: CameraFile) -> Result<()> {
-    to_c_string!(folder);
-    to_c_string!(filename);
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_folder_put_file(
+    try_gp_internal!(gp_camera_folder_put_file(
       self.camera.camera,
-      folder.as_ptr() as *const c_char,
-      filename.as_ptr() as *const c_char,
+      to_c_string!(folder),
+      to_c_string!(filename),
       FileType::Normal.into(),
       file.inner,
       self.camera.context.inner
-    ))?;
+    ));
 
     Ok(())
   }
 
   /// Delete all files in a folder
   pub fn folder_delete_all(&self, folder: &str) -> Result<()> {
-    to_c_string!(folder);
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_folder_delete_all(
+    try_gp_internal!(gp_camera_folder_delete_all(
       self.camera.camera,
-      folder.as_ptr() as *const c_char,
+      to_c_string!(folder),
       self.camera.context.inner
-    ))?;
+    ));
     Ok(())
   }
 
@@ -430,14 +413,12 @@ impl<'a> CameraFS<'a> {
   pub fn ls_files(&self, folder: &str) -> Result<Vec<String>> {
     let file_list = CameraList::new()?;
 
-    to_c_string!(folder);
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_folder_list_files(
+    try_gp_internal!(gp_camera_folder_list_files(
       self.camera.camera,
-      folder.as_ptr() as *const c_char,
+      to_c_string!(folder),
       file_list.inner,
       self.camera.context.inner
-    ))?;
+    ));
 
     Ok(file_list.to_vec()?.into_iter().map(|(name, _)| name.to_string()).collect())
   }
@@ -446,44 +427,36 @@ impl<'a> CameraFS<'a> {
   pub fn ls_folder(&self, folder: &str) -> Result<Vec<String>> {
     let folder_list = CameraList::new()?;
 
-    to_c_string!(folder);
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_folder_list_files(
+    try_gp_internal!(gp_camera_folder_list_files(
       self.camera.camera,
-      folder.as_ptr() as *const c_char,
+      to_c_string!(folder),
       folder_list.inner,
       self.camera.context.inner
-    ))?;
+    ));
 
     Ok(folder_list.to_vec()?.into_iter().map(|(name, _)| name.to_string()).collect())
   }
 
   /// Creates a new folder
   pub fn mkdir(&self, parent_folder: &str, new_folder: &str) -> Result<()> {
-    to_c_string!(parent_folder);
-    to_c_string!(new_folder);
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_folder_make_dir(
+    try_gp_internal!(gp_camera_folder_make_dir(
       self.camera.camera,
-      parent_folder.as_ptr() as *const c_char,
-      new_folder.as_ptr() as *const c_char,
+      to_c_string!(parent_folder),
+      to_c_string!(new_folder),
       self.camera.context.inner
-    ))?;
+    ));
 
     Ok(())
   }
 
   /// Removes a folder
   pub fn rmdir(&self, parent: &str, to_remove: &str) -> Result<()> {
-    to_c_string!(parent);
-    to_c_string!(to_remove);
-
-    try_gp_internal!(libgphoto2_sys::gp_camera_folder_remove_dir(
+    try_gp_internal!(gp_camera_folder_remove_dir(
       self.camera.camera,
-      parent.as_ptr() as *const c_char,
-      to_remove.as_ptr() as *const c_char,
+      to_c_string!(parent),
+      to_c_string!(to_remove),
       self.camera.context.inner
-    ))?;
+    ));
 
     Ok(())
   }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, ffi, mem::MaybeUninit, os::raw::c_char};
+use std::{borrow::Cow, ffi, os::raw::c_char};
 
 pub fn chars_to_cow<'a>(chars: *const c_char) -> Cow<'a, str> {
   unsafe { String::from_utf8_lossy(ffi::CStr::from_ptr(chars).to_bytes()) }
@@ -9,17 +9,9 @@ pub fn camera_text_to_str<'a>(text: libgphoto2_sys::CameraText) -> Cow<'a, str> 
 }
 
 macro_rules! to_c_string {
-  ($v: expr, $name:ident) => {
-    let $name = ffi::CString::new($v)?;
+  ($v:expr) => {
+    ffi::CString::new($v)?.as_ptr().cast::<std::os::raw::c_char>()
   };
-  ($name:ident) => {
-    to_c_string!($name, $name);
-  };
-}
-
-#[inline]
-pub unsafe fn uninit<T>() -> T {
-  MaybeUninit::zeroed().assume_init()
 }
 
 pub(crate) use to_c_string;

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,9 +1,6 @@
 //! List of cameras and ports
 
-use crate::{
-  helper::{chars_to_cow, uninit},
-  try_gp_internal, InnerPtr, Result,
-};
+use crate::{helper::chars_to_cow, try_gp_internal, InnerPtr, Result};
 use std::{borrow::Cow, ffi, marker::PhantomData};
 
 /// List of string tuples
@@ -28,9 +25,7 @@ impl<'a> InnerPtr<'a, libgphoto2_sys::CameraList> for CameraList<'a> {
 
 impl CameraList<'_> {
   pub(crate) fn new() -> Result<Self> {
-    let mut list = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_list_new(&mut list))?;
+    try_gp_internal!(gp_list_new(&out list));
 
     Ok(Self { inner: list, phantom: PhantomData })
   }
@@ -42,10 +37,8 @@ impl CameraList<'_> {
     let mut res = Vec::with_capacity(length as usize);
 
     for list_index in 0..length {
-      let (mut name, mut value) = unsafe { (uninit(), uninit()) };
-
-      try_gp_internal!(libgphoto2_sys::gp_list_get_name(self.inner, list_index, &mut name))?;
-      try_gp_internal!(libgphoto2_sys::gp_list_get_value(self.inner, list_index, &mut value))?;
+      try_gp_internal!(gp_list_get_name(self.inner, list_index, &out name));
+      try_gp_internal!(gp_list_get_value(self.inner, list_index, &out value));
 
       res.push((chars_to_cow(name), chars_to_cow(value)));
     }

--- a/src/port.rs
+++ b/src/port.rs
@@ -16,10 +16,7 @@
 //! # }
 //! ```
 
-use crate::{
-  helper::{chars_to_cow, uninit},
-  try_gp_internal, Inner, InnerPtr, Result,
-};
+use crate::{helper::chars_to_cow, try_gp_internal, Inner, InnerPtr, Result};
 use std::{borrow::Cow, fmt};
 
 /// Type of the port
@@ -115,27 +112,21 @@ impl PortType {
 impl PortInfo {
   /// Name of the port
   pub fn name(&self) -> Result<Cow<str>> {
-    let mut name = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_port_info_get_name(self.inner, &mut name))?;
+    try_gp_internal!(gp_port_info_get_name(self.inner, &out name));
 
     Ok(chars_to_cow(name))
   }
 
   /// Path of the port
   pub fn path(&self) -> Result<Cow<str>> {
-    let mut path = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_port_info_get_path(self.inner, &mut path))?;
+    try_gp_internal!(gp_port_info_get_path(self.inner, &out path));
 
     Ok(chars_to_cow(path))
   }
 
   /// [Port type](PortType)
   pub fn port_type(&self) -> Result<Option<PortType>> {
-    let mut port_type = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_port_info_get_type(self.inner, &mut port_type))?;
+    try_gp_internal!(gp_port_info_get_type(self.inner, &out port_type));
 
     Ok(PortType::new(port_type))
   }
@@ -143,18 +134,14 @@ impl PortInfo {
 
 impl PortInfoList {
   pub(crate) fn new() -> Result<Self> {
-    let mut port_info_list = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_port_info_list_new(&mut port_info_list))?;
-    try_gp_internal!(libgphoto2_sys::gp_port_info_list_load(port_info_list))?;
+    try_gp_internal!(gp_port_info_list_new(&out port_info_list));
+    try_gp_internal!(gp_port_info_list_load(port_info_list));
 
     Ok(Self { inner: port_info_list })
   }
 
   pub(crate) fn get_port_info(&self, p: i32) -> Result<PortInfo> {
-    let mut port_info = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_port_info_list_get_info(self.inner, p, &mut port_info))?;
+    try_gp_internal!(gp_port_info_list_get_info(self.inner, p, &out port_info));
 
     Ok(port_info.into())
   }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -16,7 +16,7 @@
 //! ```
 
 use crate::{
-  helper::{chars_to_cow, to_c_string, uninit},
+  helper::{chars_to_cow, to_c_string},
   try_gp_internal, InnerPtr, Result,
 };
 use std::{
@@ -28,11 +28,7 @@ use std::{
 
 macro_rules! get_widget_value {
   ($widget:expr, $tp:ty) => {{
-    let mut value: $tp = unsafe { $crate::helper::uninit() };
-    $crate::try_gp_internal!(libgphoto2_sys::gp_widget_get_value(
-      $widget,
-      &mut value as *mut $tp as *mut c_void
-    ))?;
+    $crate::try_gp_internal!(gp_widget_get_value($widget, &out value as *mut $tp as *mut c_void));
     value
   }};
 }
@@ -141,44 +137,34 @@ impl<'a> Widget<'a> {
 
   /// If true, the widget cannot be written
   pub fn readonly(&self) -> Result<bool> {
-    let mut readonly = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_widget_get_readonly(self.inner, &mut readonly))?;
+    try_gp_internal!(gp_widget_get_readonly(self.inner, &out readonly));
 
     Ok(readonly == 1)
   }
 
   /// Get the widget label
   pub fn label(&self) -> Result<Cow<str>> {
-    let mut label = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_widget_get_label(self.inner, &mut label))?;
+    try_gp_internal!(gp_widget_get_label(self.inner, &out label));
 
     Ok(chars_to_cow(label))
   }
 
   /// Get the widget name
   pub fn name(&self) -> Result<Cow<str>> {
-    let mut name = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_widget_get_name(self.inner, &mut name))?;
+    try_gp_internal!(gp_widget_get_name(self.inner, &out name));
     Ok(chars_to_cow(name))
   }
 
   /// Get the widget id
   pub fn id(&self) -> Result<i32> {
-    let mut id = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_widget_get_id(self.inner, &mut id))?;
+    try_gp_internal!(gp_widget_get_id(self.inner, &out id));
 
     Ok(id)
   }
 
   /// Get information about the widget
   pub fn info(&self) -> Result<Cow<str>> {
-    let mut info = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_widget_get_info(self.inner, &mut info))?;
+    try_gp_internal!(gp_widget_get_info(self.inner, &out info));
 
     Ok(chars_to_cow(info))
   }
@@ -190,58 +176,34 @@ impl<'a> Widget<'a> {
 
   /// Counts the children of the widget
   pub fn children_count(&self) -> Result<usize> {
-    try_gp_internal!(libgphoto2_sys::gp_widget_count_children(self.inner))
-      .map(|count| count as usize)
+    try_gp_internal!(let count = gp_widget_count_children(self.inner));
+    Ok(count as usize)
   }
 
   /// Gets a child by its index
   pub fn get_child(&self, index: usize) -> Result<Widget<'a>> {
-    let mut child = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_widget_get_child(self.inner, index as c_int, &mut child))?;
+    try_gp_internal!(gp_widget_get_child(self.inner, index as c_int, &out child));
 
     Ok(Self::new(child))
   }
 
   /// Get a child by its id
   pub fn get_child_by_id(&self, id: usize) -> Result<Widget<'a>> {
-    let mut child = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_widget_get_child_by_id(
-      self.inner,
-      id as c_int,
-      &mut child
-    ))?;
+    try_gp_internal!(gp_widget_get_child_by_id(self.inner, id as c_int, &out child));
 
     Ok(Self::new(child))
   }
 
   /// Get a child by its label
   pub fn get_child_by_label(&self, label: &str) -> Result<Widget<'a>> {
-    let mut child = unsafe { uninit() };
-
-    to_c_string!(label);
-
-    try_gp_internal!(libgphoto2_sys::gp_widget_get_child_by_label(
-      self.inner,
-      label.as_ptr() as *const c_char,
-      &mut child
-    ))?;
+    try_gp_internal!(gp_widget_get_child_by_label(self.inner, to_c_string!(label), &out child));
 
     Ok(Self::new(child))
   }
 
   /// Get a child by its name
   pub fn get_child_by_name(&self, name: &str) -> Result<Widget<'a>> {
-    let mut child = unsafe { uninit() };
-
-    to_c_string!(name);
-
-    try_gp_internal!(libgphoto2_sys::gp_widget_get_child_by_name(
-      self.inner,
-      name.as_ptr() as *const c_char,
-      &mut child
-    ))?;
+    try_gp_internal!(gp_widget_get_child_by_name(self.inner, to_c_string!(name), &out child));
 
     Ok(Self::new(child))
   }
@@ -250,39 +212,24 @@ impl<'a> Widget<'a> {
   pub fn widget_type(&self) -> Result<WidgetType> {
     use libgphoto2_sys::CameraWidgetType;
 
-    let mut widget_type = unsafe { uninit() };
-
-    try_gp_internal!(libgphoto2_sys::gp_widget_get_type(self.inner, &mut widget_type))?;
+    try_gp_internal!(gp_widget_get_type(self.inner, &out widget_type));
 
     Ok(match widget_type {
       CameraWidgetType::GP_WIDGET_WINDOW => WidgetType::Window,
       CameraWidgetType::GP_WIDGET_SECTION => WidgetType::Section,
       CameraWidgetType::GP_WIDGET_TEXT => WidgetType::Text,
       CameraWidgetType::GP_WIDGET_RANGE => {
-        let (mut min, mut max, mut increment) = unsafe { (uninit(), uninit(), uninit()) };
-
-        try_gp_internal!(libgphoto2_sys::gp_widget_get_range(
-          self.inner,
-          &mut min,
-          &mut max,
-          &mut increment
-        ))?;
+        try_gp_internal!(gp_widget_get_range(self.inner, &out min, &out max, &out increment));
 
         WidgetType::Range { min, max, increment }
       }
       CameraWidgetType::GP_WIDGET_TOGGLE => WidgetType::Toggle,
       CameraWidgetType::GP_WIDGET_MENU | CameraWidgetType::GP_WIDGET_RADIO => {
-        let choice_count = try_gp_internal!(libgphoto2_sys::gp_widget_count_choices(self.inner))?;
+        try_gp_internal!(let choice_count = gp_widget_count_choices(self.inner));
         let mut choices = Vec::with_capacity(choice_count as usize);
 
         for choice_i in 0..choice_count {
-          let mut choice = unsafe { uninit() };
-
-          try_gp_internal!(libgphoto2_sys::gp_widget_get_choice(
-            self.inner,
-            choice_i,
-            &mut choice
-          ))?;
+          try_gp_internal!(gp_widget_get_choice(self.inner, choice_i, &out choice));
 
           choices.push(chars_to_cow(choice).to_string());
         }
@@ -343,11 +290,7 @@ impl<'a> Widget<'a> {
       WidgetType::Button => Err("Button has no value")?,
       WidgetType::Text => {
         if let WidgetValue::Text(text) = value {
-          to_c_string!(text);
-          try_gp_internal!(libgphoto2_sys::gp_widget_set_value(
-            self.inner,
-            text.as_ptr() as *const c_void
-          ))?;
+          try_gp_internal!(gp_widget_set_value(self.inner, to_c_string!(text).cast::<c_void>()));
         } else {
           Err("Expected value to be a string")?;
         }
@@ -358,10 +301,10 @@ impl<'a> Widget<'a> {
             Err("Value out of range")?;
           }
 
-          try_gp_internal!(libgphoto2_sys::gp_widget_set_value(
+          try_gp_internal!(gp_widget_set_value(
             self.inner,
             &range_value as *const f32 as *const c_void
-          ))?;
+          ));
         } else {
           Err("Expected value to be Range")?;
         }
@@ -369,20 +312,20 @@ impl<'a> Widget<'a> {
       WidgetType::Toggle => {
         if let WidgetValue::Toggle(toggle_value) = value {
           let toggle_value = if toggle_value { 1 } else { 0 };
-          try_gp_internal!(libgphoto2_sys::gp_widget_set_value(
+          try_gp_internal!(gp_widget_set_value(
             self.inner,
             &toggle_value as *const c_int as *const c_void
-          ))?;
+          ));
         } else {
           Err("Expected value to be Toggle")?;
         }
       }
       WidgetType::Date => {
         if let WidgetValue::Date(unix_date) = value {
-          try_gp_internal!(libgphoto2_sys::gp_widget_set_value(
+          try_gp_internal!(gp_widget_set_value(
             self.inner,
             &unix_date as *const c_int as *const c_void
-          ))?;
+          ));
         } else {
           Err("Expected value to be Date")?;
         }
@@ -393,12 +336,7 @@ impl<'a> Widget<'a> {
             Err("Choice not in choices")?;
           }
 
-          to_c_string!(choice);
-
-          try_gp_internal!(libgphoto2_sys::gp_widget_set_value(
-            self.inner,
-            choice.as_ptr() as *const c_void
-          ))?;
+          try_gp_internal!(gp_widget_set_value(self.inner, to_c_string!(choice).cast::<c_void>()));
         } else {
           Err("Expected value to be Menu")?;
         }


### PR DESCRIPTION
As [`MaybeUninit` docs](https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#initialization-invariant) say, `MaybeUninit::uninit().assume_init()` as well as `MaybeUninit::zeroed().assume_init()`, which was exposed as `helper::uninit`, is UB and, as any UB, can lead to surprising bugs and corruption.

The reason is that it goes against the purpose of `MaybeUninit` - temporarily marking a place as potentially uninitialized, so that compiler doesn't assume anything about the data it holds. Instead, we must create `MaybeUninit::uninit()`, use it as a target for writes, and convert via `.assume_init()` only when we are sure it's initialized with valid data.

To make this easy, I've extended the `try_gp_internal!` macro with support for a special `&out some_var` annotation. When such annotation is used, macro will automatically generate `MaybeUninit` holders before the libgphoto2 call, invoke the function with `.as_mut_ptr()` in place of each `&out` argument, check the status code, return error if any, and only if it's successful, generate variables with actual values of each holder via `.assume_init()`, thus ensuring that uninitialized holders are never accesssed as if they contained valid data.

I've also made few more convenience changes along the way, such as auto-adding `libgphoto2_sys::` prefix since its functions are the only target of this macro, as well as making `to_c_string!` macro to return expressions.