### PR TITLE
Replace Inner and InnerPtr with AsRef/AsMut

### DIFF
--- a/src/abilities.rs
+++ b/src/abilities.rs
@@ -2,7 +2,8 @@
 //!
 //! The device abilities describe the abilities of the driver used to connect to a device.
 
-use crate::{context::Context, helper::chars_to_cow, try_gp_internal, Inner, InnerPtr, Result};
+use crate::helper::as_ref;
+use crate::{context::Context, helper::chars_to_cow, try_gp_internal, Result};
 use std::{borrow::Cow, fmt, os::raw::c_int};
 
 pub(crate) struct AbilitiesList {
@@ -144,17 +145,9 @@ impl fmt::Debug for Abilities {
   }
 }
 
-impl InnerPtr<libgphoto2_sys::CameraAbilitiesList> for AbilitiesList {
-  unsafe fn inner_mut_ptr(&self) -> &*mut libgphoto2_sys::CameraAbilitiesList {
-    &self.inner
-  }
-}
+as_ref!(AbilitiesList -> libgphoto2_sys::CameraAbilitiesList, *self.inner);
 
-impl Inner<libgphoto2_sys::CameraAbilities> for Abilities {
-  unsafe fn inner(&self) -> &libgphoto2_sys::CameraAbilities {
-    &self.inner
-  }
-}
+as_ref!(Abilities -> libgphoto2_sys::CameraAbilities, self.inner);
 
 impl AbilitiesList {
   pub(crate) fn new(context: &Context) -> Result<Self> {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -4,11 +4,11 @@ use crate::{
   abilities::Abilities,
   file::{CameraFile, CameraFilePath},
   filesys::{CameraFS, StorageInfo},
-  helper::{camera_text_to_str, chars_to_cow, to_c_string},
+  helper::{as_ref, camera_text_to_str, chars_to_cow, to_c_string},
   port::PortInfo,
   try_gp_internal,
   widget::{Widget, WidgetType},
-  InnerPtr, Result,
+  Result,
 };
 use std::{borrow::Cow, ffi, os::raw::c_char, time::Duration};
 
@@ -93,11 +93,7 @@ impl Drop for Camera {
   }
 }
 
-impl InnerPtr<libgphoto2_sys::Camera> for Camera {
-  unsafe fn inner_mut_ptr(&self) -> &*mut libgphoto2_sys::Camera {
-    &self.camera
-  }
-}
+as_ref!(Camera -> libgphoto2_sys::Camera, *self.camera);
 
 impl Camera {
   pub(crate) fn new(

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,8 @@
 //! Library context
+use crate::helper::as_ref;
 use crate::{
   abilities::AbilitiesList, camera::Camera, list::CameraList, port::PortInfoList, try_gp_internal,
-  Error, InnerPtr, Result,
+  Error, Result,
 };
 use std::ffi;
 
@@ -36,11 +37,7 @@ impl Drop for Context {
   }
 }
 
-impl InnerPtr<libgphoto2_sys::GPContext> for Context {
-  unsafe fn inner_mut_ptr(&self) -> &*mut libgphoto2_sys::GPContext {
-    &self.inner
-  }
-}
+as_ref!(Context -> libgphoto2_sys::GPContext, *self.inner);
 
 impl Context {
   /// Create a new context

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,8 +1,6 @@
 //! Files stored on camera
 
-use crate::{
-  camera::Camera, error::Error, helper::chars_to_cow, try_gp_internal, Inner, InnerPtr, Result,
-};
+use crate::{camera::Camera, error::Error, helper::chars_to_cow, try_gp_internal, Result};
 use std::{borrow::Cow, ffi, fmt, fs, path::Path};
 
 #[cfg(unix)]
@@ -61,7 +59,7 @@ mod owned_fd_impl {
   }
 }
 
-use crate::helper::to_c_string;
+use crate::helper::{as_ref, to_c_string};
 use owned_fd_impl::OwnedFd;
 
 /// Represents a path of a file on a camera
@@ -168,17 +166,9 @@ impl fmt::Debug for CameraFilePath {
   }
 }
 
-impl InnerPtr<libgphoto2_sys::CameraFile> for CameraFile {
-  unsafe fn inner_mut_ptr(&self) -> &*mut libgphoto2_sys::CameraFile {
-    &self.inner
-  }
-}
+as_ref!(CameraFile -> libgphoto2_sys::CameraFile, *self.inner);
 
-impl Inner<libgphoto2_sys::CameraFilePath> for CameraFilePath {
-  unsafe fn inner(&self) -> &libgphoto2_sys::CameraFilePath {
-    &self.inner
-  }
-}
+as_ref!(CameraFilePath -> libgphoto2_sys::CameraFilePath, self.inner);
 
 impl CameraFilePath {
   /// Get the name of the file's folder

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -14,4 +14,28 @@ macro_rules! to_c_string {
   };
 }
 
-pub(crate) use to_c_string;
+macro_rules! as_ref {
+  ($from:ident -> $to:ty, $self:ident . $field:ident) => {
+    as_ref!(@ $from -> $to, , $self, $self.$field);
+  };
+
+  ($from:ident -> $to:ty, * $self:ident . $field:ident) => {
+    as_ref!(@ $from -> $to, unsafe, $self, *$self.$field);
+  };
+
+  (@ $from:ident -> $to:ty, $($unsafe:ident)?, $self:ident, $value:expr) => {
+    impl AsRef<$to> for $from {
+      fn as_ref(&$self) -> &$to {
+        $($unsafe)? { & $value }
+      }
+    }
+
+    impl AsMut<$to> for $from {
+      fn as_mut(&mut $self) -> &mut $to {
+        $($unsafe)? { &mut $value }
+      }
+    }
+  };
+}
+
+pub(crate) use {as_ref, to_c_string};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,23 +24,3 @@ pub use crate::{
 ///
 /// Use this at your own risk
 pub use libgphoto2_sys;
-
-/// Trait to get the underlying libgphoto2 pointer of a wrapper
-pub trait InnerPtr<T> {
-  /// Get a reference to the inner *mut raw pointer
-  ///
-  /// # Safety
-  ///
-  /// Interacting with the underlying libgphoto2 pointers can be dangerous, **use this at your own risk**
-  unsafe fn inner_mut_ptr(&self) -> &*mut T;
-}
-
-/// Trait to get the underlying libgphoto2 value of a wrapper
-pub trait Inner<T> {
-  /// Get a reference to the inner value
-  ///
-  /// # Safety
-  ///
-  /// Interacting with the underlying libgphoto2 values can be dangerous, **use this at your own risk**
-  unsafe fn inner(&self) -> &T;
-}

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,6 +1,7 @@
 //! List of cameras and ports
 
-use crate::{helper::chars_to_cow, try_gp_internal, InnerPtr, Result};
+use crate::helper::as_ref;
+use crate::{helper::chars_to_cow, try_gp_internal, Result};
 use std::borrow::Cow;
 
 /// List of string tuples
@@ -16,11 +17,7 @@ impl Drop for CameraList {
   }
 }
 
-impl InnerPtr<libgphoto2_sys::CameraList> for CameraList {
-  unsafe fn inner_mut_ptr(&self) -> &*mut libgphoto2_sys::CameraList {
-    &self.inner
-  }
-}
+as_ref!(CameraList -> libgphoto2_sys::CameraList, *self.inner);
 
 impl CameraList {
   pub(crate) fn new() -> Result<Self> {

--- a/src/port.rs
+++ b/src/port.rs
@@ -16,7 +16,8 @@
 //! # }
 //! ```
 
-use crate::{helper::chars_to_cow, try_gp_internal, Inner, InnerPtr, Result};
+use crate::helper::as_ref;
+use crate::{helper::chars_to_cow, try_gp_internal, Result};
 use std::{borrow::Cow, fmt};
 
 /// Type of the port
@@ -80,17 +81,9 @@ impl fmt::Debug for PortInfo {
   }
 }
 
-impl InnerPtr<libgphoto2_sys::GPPortInfoList> for PortInfoList {
-  unsafe fn inner_mut_ptr(&self) -> &*mut libgphoto2_sys::GPPortInfoList {
-    &self.inner
-  }
-}
+as_ref!(PortInfoList -> libgphoto2_sys::GPPortInfoList, *self.inner);
 
-impl Inner<libgphoto2_sys::GPPortInfo> for PortInfo {
-  unsafe fn inner(&self) -> &libgphoto2_sys::GPPortInfo {
-    &self.inner
-  }
-}
+as_ref!(PortInfo -> libgphoto2_sys::GPPortInfo, self.inner);
 
 impl PortType {
   fn new(port_type: libgphoto2_sys::GPPortType) -> Option<Self> {

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -16,8 +16,8 @@
 //! ```
 
 use crate::{
-  helper::{chars_to_cow, to_c_string},
-  try_gp_internal, InnerPtr, Result,
+  helper::{as_ref, chars_to_cow, to_c_string},
+  try_gp_internal, Result,
 };
 use std::{
   borrow::Cow,
@@ -113,11 +113,7 @@ impl fmt::Debug for Widget {
   }
 }
 
-impl InnerPtr<libgphoto2_sys::CameraWidget> for Widget {
-  unsafe fn inner_mut_ptr(&self) -> &*mut libgphoto2_sys::CameraWidget {
-    &self.inner
-  }
-}
+as_ref!(Widget -> libgphoto2_sys::CameraWidget, *self.inner);
 
 impl Widget {
   pub(crate) fn new(widget: *mut libgphoto2_sys::CameraWidget) -> Self {


### PR DESCRIPTION
This replaces custom traits for inner pointers with safe, lifetime-bound access, via standard traits AsRef and AsMut. Of course, the caller will still be forced to use `unsafe` for any FFI calls that operate on those pointers, but the access to references themselves is safe and becomes a bit more convenient via those traits.