### PR TITLE
Improve bitflags handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ readme = "README.md"
 members = ["libgphoto2-sys"]
 
 [dependencies]
-libgphoto2_sys = { path = "libgphoto2-sys", version = "1.0.1" }
+libgphoto2_sys = { path = "libgphoto2-sys", version = "1.1" }
 libc = "0.2"

--- a/libgphoto2-sys/Cargo.toml
+++ b/libgphoto2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgphoto2_sys"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 description = "System bindings to libgphoto2"
 repository = "https://git.maxicarlos.de/maxicarlos08/gphoto2-rs"

--- a/libgphoto2-sys/src/build.rs
+++ b/libgphoto2-sys/src/build.rs
@@ -13,6 +13,7 @@ fn main() {
     .generate_comments(true)
     .parse_callbacks(Box::new(bindgen::CargoCallbacks))
     .default_enum_style(bindgen::EnumVariation::Rust { non_exhaustive: false })
+    .bitfield_enum("^Camera(FilePermissions|(File|Folder)?Operation)$")
     .generate()
     .expect("Unable to generate bindings");
 

--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -2,7 +2,7 @@
 
 use crate::{
   file::{CameraFile, FileType},
-  helper::{chars_to_cow, to_c_string},
+  helper::{bitflags, chars_to_cow, to_c_string},
   list::CameraList,
   try_gp_internal, Camera, Result,
 };
@@ -78,8 +78,16 @@ pub enum FileStatus {
   NotDownloaded,
 }
 
-/// Permissions of a [`CameraFile`]
-pub struct FilePermissions(c_int);
+bitflags!(
+  /// Permissions of a [`CameraFile`]
+  FilePermissions = CameraFilePermissions {
+    /// File can be read
+    read: GP_FILE_PERM_READ,
+
+    /// File can be deleted
+    delete: GP_FILE_PERM_DELETE,
+  }
+);
 
 /// Image thumbnail information
 pub struct FileInfoPreview {
@@ -203,12 +211,6 @@ impl From<libgphoto2_sys::CameraFileInfoPreview> for FileInfoPreview {
   }
 }
 
-impl From<libgphoto2_sys::CameraFilePermissions> for FilePermissions {
-  fn from(permissions: libgphoto2_sys::CameraFilePermissions) -> Self {
-    Self(permissions as c_int)
-  }
-}
-
 impl From<libgphoto2_sys::CameraFileInfoFile> for FileInfoFile {
   fn from(file_info: libgphoto2_sys::CameraFileInfoFile) -> Self {
     Self {
@@ -256,18 +258,6 @@ impl fmt::Debug for StorageInfo {
       .field("free", &self.free())
       .field("free_images", &self.free_images())
       .finish()
-  }
-}
-
-impl FilePermissions {
-  /// File can be read
-  pub fn read(&self) -> bool {
-    self.0 & libgphoto2_sys::CameraFilePermissions::GP_FILE_PERM_READ as c_int != 0
-  }
-
-  /// File can be deleted
-  pub fn delete(&self) -> bool {
-    self.0 & libgphoto2_sys::CameraFilePermissions::GP_FILE_PERM_DELETE as c_int != 0
   }
 }
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -14,4 +14,38 @@ macro_rules! to_c_string {
   };
 }
 
-pub(crate) use to_c_string;
+macro_rules! bitflags {
+  ($(# $attr:tt)* $name:ident = $target:ident { $($(# $field_attr:tt)* $field:ident: $value:ident,)* }) => {
+    $(# $attr)*
+    #[derive(Clone, Hash, PartialEq, Eq)]
+    pub struct $name(libgphoto2_sys::$target);
+
+    impl From<libgphoto2_sys::$target> for $name {
+      fn from(flags: libgphoto2_sys::$target) -> Self {
+        Self(flags)
+      }
+    }
+
+    impl $name {
+      $(
+        $(# $field_attr)*
+        #[inline]
+        pub fn $field(&self) -> bool {
+          (self.0 & libgphoto2_sys::$target::$value).0 != 0
+        }
+      )*
+    }
+
+    impl std::fmt::Debug for $name {
+      fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(stringify!($name))
+          $(
+            .field(stringify!($field), &self.$field())
+          )*
+          .finish()
+      }
+    }
+  };
+}
+
+pub(crate) use {bitflags, to_c_string};


### PR DESCRIPTION
 - Mark bitflag enums as such at the `libghoto2-sys` level. They're not really enums in the Rust sense, and treating them as such might be UB due to trying to store values out of enum range (e.g. storing `1|2 = 3` in an enum that supports only `{0,1,2}`). Such designation makes bindgen generate structs instead, with associated constants and some convenient bit trait implementations.
 - Add `bitflags!` macro to gphoto2-rs that generates `fn field(&self) -> bool` helpers as well as `From<...>` and a readable `Debug` implementation.