### PR TITLE
Widgets revamp

### DIFF
--- a/examples/bulb_capture.rs
+++ b/examples/bulb_capture.rs
@@ -3,26 +3,27 @@
 //! There are also actions for capturing movies, changing liveview, etc.  
 //! This example will only work for Nikon DSLR cameras.
 
-use gphoto2::{camera::CameraEvent, widget::WidgetValue, Context, Result};
+use gphoto2::widget::{RadioWidget, ToggleWidget};
+use gphoto2::{camera::CameraEvent, Context, Result};
 use std::{thread::sleep, time::Duration};
 
 fn main() -> Result<()> {
   let camera = Context::new()?.autodetect_camera()?;
 
-  let mut shutter_speed = camera.config_key("shutterspeed")?;
-  let mut bulb_setting = camera.config_key("bulb")?;
+  let shutter_speed = camera.config_key::<RadioWidget>("shutterspeed")?;
+  let bulb_setting = camera.config_key::<ToggleWidget>("bulb")?;
 
-  shutter_speed.set_value(WidgetValue::Menu("Bulb".to_string()))?;
+  shutter_speed.set_choice("Bulb")?;
   camera.set_config(&shutter_speed)?;
 
   println!("Starting bulb capture");
 
-  bulb_setting.set_value(WidgetValue::Toggle(Some(true)))?;
+  bulb_setting.set_toggled(true)?;
   camera.set_config(&bulb_setting)?;
 
   sleep(Duration::from_secs(2));
 
-  bulb_setting.set_value(WidgetValue::Toggle(Some(false)))?;
+  bulb_setting.set_toggled(false)?;
   camera.set_config(&bulb_setting)?;
 
   let mut retry = 0;

--- a/examples/list_config.rs
+++ b/examples/list_config.rs
@@ -1,35 +1,10 @@
 //! Recursively list all configuration
 //! Warning: Output might be very large
 
-use gphoto2::{widget::Widget, Context, Result};
-
-fn display_widget_recursive(widget: &Widget, prefix: &str) -> Result<()> {
-  let name = widget.name()?;
-  let id = widget.id()?;
-  let new_prefix = format!("{prefix}/{name}");
-
-  println!("{} ({})", new_prefix, id);
-  println!("LABEL: {}", widget.label()?);
-  println!("READONLY: {}", widget.readonly()?);
-  println!("TYPE: {:#?}", widget.widget_type()?);
-
-  if let Ok((Some(value), _)) = widget.value() {
-    println!("VALUE: {:?}", value)
-  }
-
-  println!();
-
-  for child in widget.children_iter()? {
-    display_widget_recursive(&child, &new_prefix)?;
-  }
-
-  Ok(())
-}
+use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
   let camera = Context::new()?.autodetect_camera()?;
-
-  display_widget_recursive(&camera.config()?, "")?;
-
+  println!("{:#?}", camera.config()?);
   Ok(())
 }

--- a/examples/opcode.rs
+++ b/examples/opcode.rs
@@ -4,22 +4,23 @@
 //! This example starts and ends live view mode on the camera for 10 s,
 //! this example only works on Nikon cameras.
 
-use gphoto2::{widget::WidgetValue, Context, Result};
+use gphoto2::widget::TextWidget;
+use gphoto2::{Context, Result};
 use std::{thread, time::Duration};
 
 fn main() -> Result<()> {
   let camera = Context::new()?.autodetect_camera()?;
 
-  let mut opcode = camera.config_key("opcode")?;
+  let opcode = camera.config_key::<TextWidget>("opcode")?;
 
   println!("Starting live view");
-  opcode.set_value(WidgetValue::Text("0x9201".into()))?;
+  opcode.set_value("0x9201")?;
   camera.set_config(&opcode)?;
 
   thread::sleep(Duration::from_secs(10));
 
   println!("Ending live view");
-  opcode.set_value(WidgetValue::Text("0x9202".into()))?;
+  opcode.set_value("0x9202")?;
   camera.set_config(&opcode)?;
 
   Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -106,9 +106,21 @@ impl From<std::ffi::NulError> for Error {
   }
 }
 
+impl From<std::convert::Infallible> for Error {
+  fn from(err: std::convert::Infallible) -> Self {
+    match err {}
+  }
+}
+
+impl From<String> for Error {
+  fn from(message: String) -> Self {
+    Self { error: libgphoto2_sys::GP_ERROR, info: Some(message) }
+  }
+}
+
 impl From<&str> for Error {
   fn from(message: &str) -> Self {
-    Self { error: libgphoto2_sys::GP_ERROR, info: Some(message.into()) }
+    message.to_owned().into()
   }
 }
 
@@ -147,6 +159,7 @@ macro_rules! try_gp_internal {
   };
 
   (@ $status:tt [ $($out:ident)* ] $func:ident $args:tt) => {
+    #[allow(unused_unsafe)]
     let ($status, $($out),*) = unsafe {
       $(let mut $out = std::mem::MaybeUninit::uninit();)*
 

--- a/src/port.rs
+++ b/src/port.rs
@@ -17,7 +17,7 @@
 //! ```
 
 use crate::{
-  helper::{as_ref, chars_to_string},
+  helper::{as_ref, chars_to_string, FmtResult},
   try_gp_internal, Result,
 };
 use std::fmt;
@@ -76,9 +76,9 @@ impl From<libgphoto2_sys::GPPortInfo> for PortInfo {
 impl fmt::Debug for PortInfo {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.debug_struct("PortInfo")
-      .field("name", &self.name().ok())
-      .field("path", &self.path().ok())
-      .field("port_type", &self.port_type().ok().flatten())
+      .field("name", self.name().fmt_res())
+      .field("path", self.path().fmt_res())
+      .field("port_type", self.port_type().fmt_res())
       .finish()
   }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -71,7 +71,7 @@ impl WidgetBase {
   }
 
   /// Get exact widget type.
-  pub fn ty(&self) -> Result<libgphoto2_sys::CameraWidgetType> {
+  fn ty(&self) -> Result<libgphoto2_sys::CameraWidgetType> {
     try_gp_internal!(gp_widget_get_type(self.inner, &out widget_type));
     Ok(widget_type)
   }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -2,91 +2,62 @@
 //!
 //! ## Configuring a camera
 //! ```no_run
-//! use gphoto2::{Context, widget::WidgetValue, Result};
+//! use gphoto2::{Context, widget::RadioWidget, Result};
 //!
 //! # fn main() -> Result<()> {
 //! let context = Context::new()?;
 //! let camera = context.autodetect_camera()?;
 //!
-//! let mut config = camera.config_key("iso")?;
-//! config.set_value(WidgetValue::Menu("100".to_string()))?; // Set the iso to 100
+//! let mut config = camera.config_key::<RadioWidget>("iso")?;
+//! config.set_choice("100")?; // Set the iso to 100
 //! camera.set_config(&config); // Apply setting to camera
 //! # Ok(())
 //! # }
 //! ```
 
 use crate::{
-  helper::{as_ref, chars_to_string, to_c_string},
-  try_gp_internal, Result,
+  helper::{as_ref, chars_to_string, to_c_string, FmtResult},
+  try_gp_internal, Camera, Error, Result,
 };
 use std::{
   ffi, fmt,
-  os::raw::{c_int, c_void},
+  ops::{Range, RangeInclusive},
+  os::raw::{c_char, c_int, c_void},
 };
-
-/// Value of a widget
-#[derive(Debug, PartialEq, Clone)]
-pub enum WidgetValue {
-  /// Textual data
-  Text(String),
-  /// Float in a range
-  Range(f32),
-  /// Checkbox (if None the state is unknown)
-  ///
-  /// Note that you cannot set a toggle to an unknown state
-  Toggle(Option<bool>),
-  /// Selected choice
-  Menu(String),
-  /// Date
-  Date(c_int),
-}
-
-/// Type of a widget
-#[derive(Debug, PartialEq, Clone)]
-pub enum WidgetType {
-  /// Root configuration object
-  Window,
-  /// Configuration section
-  Section,
-  /// Text configuration
-  Text,
-  /// Range configuration
-  Range {
-    /// Minimum value
-    min: f32,
-    /// Maximum value
-    max: f32,
-    /// Step
-    increment: f32,
-  },
-  /// Boolean
-  Toggle,
-  /// Choice between many values
-  Menu {
-    /// Choices
-    choices: Vec<String>,
-    /// If the value was internally represented as radio (which is the same)
-    radio: bool,
-  },
-  /// Button
-  Button,
-  /// Date
-  Date,
-}
 
 /// Iterator over the children of a widget
 pub struct WidgetIterator<'a> {
-  parent_widget: &'a Widget,
-  count: usize,
-  index: usize,
+  parent_widget: &'a GroupWidget,
+  range: Range<usize>,
 }
 
-/// A configuration widget
-pub struct Widget {
+impl<'a> Iterator for WidgetIterator<'a> {
+  type Item = Widget;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    self.range.next().map(|i| self.parent_widget.get_child(i).unwrap())
+  }
+}
+
+/// Base widget type providing general information about the widget.
+///
+/// Normally you shouldn't use this type directly but should acccess its
+/// properties via [`Widget`] or specific typed widgets instead.
+pub struct WidgetBase {
   pub(crate) inner: *mut libgphoto2_sys::CameraWidget,
 }
 
-impl Drop for Widget {
+impl Clone for WidgetBase {
+  fn clone(&self) -> Self {
+    unsafe {
+      libgphoto2_sys::gp_widget_ref(self.inner);
+    }
+
+    Self { inner: self.inner }
+  }
+}
+
+impl Drop for WidgetBase {
   fn drop(&mut self) {
     unsafe {
       libgphoto2_sys::gp_widget_unref(self.inner);
@@ -94,39 +65,15 @@ impl Drop for Widget {
   }
 }
 
-impl fmt::Debug for Widget {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.debug_struct("Widget")
-      .field("id", &self.id().ok())
-      .field("name", &self.name().ok())
-      .field("label", &self.label().ok())
-      .field("readonly", &self.readonly().ok())
-      .field("widget_type", &self.widget_type().ok())
-      .field(
-        "value",
-        &match self.value() {
-          Ok((Some(value), _)) => Some(value),
-          _ => None,
-        },
-      )
-      .field("children", &self.children_iter().map(|iter| iter.collect::<Vec<Widget>>()))
-      .finish()
-  }
-}
-
-as_ref!(Widget -> libgphoto2_sys::CameraWidget, *self.inner);
-
-impl Widget {
-  pub(crate) fn new_owned(widget: *mut libgphoto2_sys::CameraWidget) -> Self {
-    Self { inner: widget }
+impl WidgetBase {
+  fn as_ptr(&self) -> *mut libgphoto2_sys::CameraWidget {
+    self.inner
   }
 
-  pub(crate) fn new_shared(widget: *mut libgphoto2_sys::CameraWidget) -> Self {
-    unsafe {
-      libgphoto2_sys::gp_widget_ref(widget);
-    }
-
-    Self::new_owned(widget)
+  /// Get exact widget type.
+  pub fn ty(&self) -> Result<libgphoto2_sys::CameraWidgetType> {
+    try_gp_internal!(gp_widget_get_type(self.inner, &out widget_type));
+    Ok(widget_type)
   }
 
   /// If true, the widget cannot be written
@@ -163,191 +110,350 @@ impl Widget {
     Ok(chars_to_string(info))
   }
 
+  fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
+    f.field("id", self.id().fmt_res())
+      .field("name", self.name().fmt_res())
+      .field("label", self.label().fmt_res())
+      .field("readonly", self.readonly().fmt_res());
+  }
+
+  unsafe fn raw_value<T>(&self) -> Result<T> {
+    try_gp_internal!(gp_widget_get_value(self.inner, &out value as *mut T as *mut c_void));
+    Ok(value)
+  }
+
+  unsafe fn set_raw_value<T>(&self, value: *const T) -> Result<()> {
+    try_gp_internal!(gp_widget_set_value(self.inner, value.cast::<c_void>()));
+    Ok(())
+  }
+}
+
+impl fmt::Debug for WidgetBase {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let mut f = f.debug_struct("WidgetBase");
+    f.field("type", &self.ty());
+    self.fmt_fields(&mut f);
+    f.finish()
+  }
+}
+
+as_ref!(WidgetBase -> libgphoto2_sys::CameraWidget, *self.inner);
+
+macro_rules! join_strings {
+  ($delim:literal, $first:expr $(, $rest:expr)*) => {
+    concat!($first $(, $delim, $rest)*)
+  };
+}
+
+macro_rules! typed_widgets {
+  ($($name:ident, $variant:ident = $($gp_name:ident)|+;)*) => {
+    /// Typed widget representation.
+    #[derive(Clone)]
+    pub enum Widget {
+      $(
+        #[doc = concat!("Variant representing a [`", stringify!($name), "`].")]
+        $variant($name),
+      )*
+    }
+
+    impl Widget {
+      pub(crate) fn new_owned(widget: *mut libgphoto2_sys::CameraWidget) -> Result<Self> {
+        let inner = WidgetBase { inner: widget };
+
+        Ok(match inner.ty()? {
+          $($(libgphoto2_sys::CameraWidgetType::$gp_name)|+ => Widget::$variant($name { inner }),)*
+        })
+      }
+    }
+
+    $(
+      impl From<$name> for Widget {
+        fn from(widget: $name) -> Self {
+          Widget::$variant(widget)
+        }
+      }
+
+      impl TryFrom<Widget> for $name {
+        type Error = Error;
+
+        fn try_from(widget: Widget) -> Result<Self> {
+          match widget {
+            Widget::$variant(widget) => Ok(widget),
+            _ => Err(Error::from(format!("Expected {} but got {:?}", stringify!($name), widget))),
+          }
+        }
+      }
+    )*
+
+    impl Widget {
+      /// Try to downcast the widget to the specific type.
+      pub fn try_into<T>(self) -> std::result::Result<T, <T as TryFrom<Widget>>::Error>
+      where
+        T: TryFrom<Widget>,
+      {
+        TryInto::try_into(self)
+      }
+    }
+
+    impl fmt::Debug for Widget {
+      fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+          $(Self::$variant(widget) => widget.fmt(f),)*
+        }
+      }
+    }
+
+    impl std::ops::Deref for Widget {
+      type Target = WidgetBase;
+
+      fn deref(&self) -> &WidgetBase {
+        match self {
+          $(Self::$variant(widget) => widget),*
+        }
+      }
+    }
+
+    $(
+      #[doc = concat!(
+        "Widget representing ",
+        join_strings!(
+          " or "
+          $(, concat!(
+            "[`", stringify!($gp_name), "`]",
+            "(libgphoto2_sys::CameraWidgetType::", stringify!($gp_name), ")"
+          ))+
+        ),
+        "."
+      )]
+      #[derive(Clone)]
+      pub struct $name {
+        inner: WidgetBase,
+      }
+
+      impl std::fmt::Debug for $name {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+          let mut f = f.debug_struct(stringify!($name));
+          // Add fields from core WidgetBase.
+          self.inner.fmt_fields(&mut f);
+          // Add fields widget itself wishes to report.
+          $name::fmt_fields(self, &mut f);
+          f.finish()
+        }
+      }
+
+      impl std::ops::Deref for $name {
+        type Target = WidgetBase;
+
+        fn deref(&self) -> &WidgetBase {
+          &self.inner
+        }
+      }
+    )*
+  };
+}
+
+typed_widgets!(
+  GroupWidget, Group = GP_WIDGET_WINDOW | GP_WIDGET_SECTION;
+  TextWidget, Text = GP_WIDGET_TEXT;
+  RangeWidget, Range = GP_WIDGET_RANGE;
+  ToggleWidget, Toggle = GP_WIDGET_TOGGLE;
+  RadioWidget, Radio = GP_WIDGET_MENU | GP_WIDGET_RADIO;
+  ButtonWidget, Button = GP_WIDGET_BUTTON;
+  DateWidget, Date = GP_WIDGET_DATE;
+);
+
+/// Helper that prints `...` when using `{:?}` or the given list when using `{:#?}`.
+struct MaybeListFmt<F>(F);
+
+impl<Iter: IntoIterator, F: Fn() -> Result<Iter>> fmt::Debug for MaybeListFmt<F>
+where
+  Iter::Item: fmt::Debug,
+{
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    if f.alternate() {
+      match (self.0)() {
+        Ok(iter) => f.debug_list().entries(iter).finish(),
+        Err(err) => err.fmt(f),
+      }
+    } else {
+      f.write_str("...")
+    }
+  }
+}
+
+impl GroupWidget {
   /// Creates a new [`WidgetIterator`]
   pub fn children_iter(&self) -> Result<WidgetIterator<'_>> {
-    Ok(WidgetIterator { parent_widget: self, count: self.children_count()?, index: 0 })
+    Ok(WidgetIterator { parent_widget: self, range: 0..self.children_count()? })
   }
 
   /// Counts the children of the widget
   pub fn children_count(&self) -> Result<usize> {
-    try_gp_internal!(let count = gp_widget_count_children(self.inner));
+    try_gp_internal!(let count = gp_widget_count_children(self.as_ptr()));
     Ok(count as usize)
   }
 
   /// Gets a child by its index
   pub fn get_child(&self, index: usize) -> Result<Widget> {
-    try_gp_internal!(gp_widget_get_child(self.inner, index as c_int, &out child));
+    try_gp_internal!(gp_widget_get_child(self.as_ptr(), index as c_int, &out child));
 
-    Ok(Self::new_shared(child))
+    Widget::new_shared(child)
   }
 
   /// Get a child by its id
   pub fn get_child_by_id(&self, id: usize) -> Result<Widget> {
-    try_gp_internal!(gp_widget_get_child_by_id(self.inner, id as c_int, &out child));
+    try_gp_internal!(gp_widget_get_child_by_id(self.as_ptr(), id as c_int, &out child));
 
-    Ok(Self::new_shared(child))
+    Widget::new_shared(child)
   }
 
   /// Get a child by its label
   pub fn get_child_by_label(&self, label: &str) -> Result<Widget> {
-    try_gp_internal!(gp_widget_get_child_by_label(self.inner, to_c_string!(label), &out child));
+    try_gp_internal!(gp_widget_get_child_by_label(self.as_ptr(), to_c_string!(label), &out child));
 
-    Ok(Self::new_shared(child))
+    Widget::new_shared(child)
   }
 
   /// Get a child by its name
   pub fn get_child_by_name(&self, name: &str) -> Result<Widget> {
-    try_gp_internal!(gp_widget_get_child_by_name(self.inner, to_c_string!(name), &out child));
+    try_gp_internal!(gp_widget_get_child_by_name(self.as_ptr(), to_c_string!(name), &out child));
 
-    Ok(Self::new_shared(child))
+    Widget::new_shared(child)
   }
 
-  /// Get the type of the widget
-  pub fn widget_type(&self) -> Result<WidgetType> {
-    use libgphoto2_sys::CameraWidgetType;
-
-    try_gp_internal!(gp_widget_get_type(self.inner, &out widget_type));
-
-    Ok(match widget_type {
-      CameraWidgetType::GP_WIDGET_WINDOW => WidgetType::Window,
-      CameraWidgetType::GP_WIDGET_SECTION => WidgetType::Section,
-      CameraWidgetType::GP_WIDGET_TEXT => WidgetType::Text,
-      CameraWidgetType::GP_WIDGET_RANGE => {
-        try_gp_internal!(gp_widget_get_range(self.inner, &out min, &out max, &out increment));
-
-        WidgetType::Range { min, max, increment }
-      }
-      CameraWidgetType::GP_WIDGET_TOGGLE => WidgetType::Toggle,
-      CameraWidgetType::GP_WIDGET_MENU | CameraWidgetType::GP_WIDGET_RADIO => {
-        try_gp_internal!(let choice_count = gp_widget_count_choices(self.inner));
-        let mut choices = Vec::with_capacity(choice_count as usize);
-
-        for choice_i in 0..choice_count {
-          try_gp_internal!(gp_widget_get_choice(self.inner, choice_i, &out choice));
-
-          choices.push(chars_to_string(choice));
-        }
-
-        WidgetType::Menu { choices, radio: widget_type == CameraWidgetType::GP_WIDGET_RADIO }
-      }
-      CameraWidgetType::GP_WIDGET_BUTTON => WidgetType::Button,
-      CameraWidgetType::GP_WIDGET_DATE => WidgetType::Date,
-    })
-  }
-
-  fn raw_value<T>(&self) -> Result<T> {
-    try_gp_internal!(gp_widget_get_value(self.inner, &out value as *mut T as *mut c_void));
-    Ok(value)
-  }
-
-  fn str_value(&self) -> Result<String> {
-    Ok(chars_to_string(self.raw_value()?))
-  }
-
-  /// Get the widget value and type
-  pub fn value(&self) -> Result<(Option<WidgetValue>, WidgetType)> {
-    let widget_type = self.widget_type()?;
-
-    Ok((
-      match widget_type {
-        WidgetType::Window | WidgetType::Button | WidgetType::Section => None,
-        WidgetType::Text => Some(WidgetValue::Text(self.str_value()?)),
-        WidgetType::Range { .. } => Some(WidgetValue::Range(self.raw_value()?)),
-        WidgetType::Toggle => Some(WidgetValue::Toggle(match self.raw_value::<c_int>()? {
-          1 => Some(true),
-          2 => None,
-          _ => Some(false),
-        })),
-        WidgetType::Date => Some(WidgetValue::Date(self.raw_value()?)),
-        WidgetType::Menu { .. } => Some(WidgetValue::Menu(self.str_value()?)),
-      },
-      widget_type,
-    ))
-  }
-
-  /// Sets the value of the widget
-  ///
-  /// **Note**: This only sets the value of the configuration, to apply the setting to the camera use [`Camera::set_config`](crate::Camera::set_config)
-  pub fn set_value(&mut self, value: WidgetValue) -> Result<()> {
-    let self_type = self.widget_type()?;
-
-    match self_type {
-      WidgetType::Window => Err("Window has no value")?,
-      WidgetType::Section => Err("Section has no value")?,
-      WidgetType::Button => Err("Button has no value")?,
-      WidgetType::Text => {
-        if let WidgetValue::Text(text) = value {
-          try_gp_internal!(gp_widget_set_value(self.inner, to_c_string!(text).cast::<c_void>()));
-        } else {
-          Err("Expected value to be a string")?;
-        }
-      }
-      WidgetType::Range { min, max, .. } => {
-        if let WidgetValue::Range(range_value) = value {
-          if (range_value < min) || (range_value > max) {
-            Err("Value out of range")?;
-          }
-
-          try_gp_internal!(gp_widget_set_value(
-            self.inner,
-            &range_value as *const f32 as *const c_void
-          ));
-        } else {
-          Err("Expected value to be Range")?;
-        }
-      }
-      WidgetType::Toggle => {
-        if let WidgetValue::Toggle(optional_toggle) = value {
-          if let Some(toggle_value) = optional_toggle {
-            try_gp_internal!(gp_widget_set_value(
-              self.inner,
-              &(toggle_value as c_int) as *const c_int as *const c_void
-            ));
-          } else {
-            Err("A toggle cannot be set to an unknown state")?;
-          }
-        } else {
-          Err("Expected value to be Toggle")?;
-        }
-      }
-      WidgetType::Date => {
-        if let WidgetValue::Date(unix_date) = value {
-          try_gp_internal!(gp_widget_set_value(
-            self.inner,
-            &unix_date as *const c_int as *const c_void
-          ));
-        } else {
-          Err("Expected value to be Date")?;
-        }
-      }
-      WidgetType::Menu { choices, .. } => {
-        if let WidgetValue::Menu(choice) = value {
-          if !choices.contains(&choice) {
-            Err("Choice not in choices")?;
-          }
-
-          try_gp_internal!(gp_widget_set_value(self.inner, to_c_string!(choice).cast::<c_void>()));
-        } else {
-          Err("Expected value to be Menu")?;
-        }
-      }
-    }
-
-    Ok(())
+  fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
+    f.field("children", &MaybeListFmt(|| self.children_iter()));
   }
 }
 
-impl<'a> Iterator for WidgetIterator<'a> {
-  type Item = Widget;
+impl TextWidget {
+  /// Get the value of the widget.
+  pub fn value(&self) -> Result<String> {
+    Ok(chars_to_string(unsafe { self.raw_value::<*const c_char>()? }))
+  }
 
-  fn next(&mut self) -> Option<Self::Item> {
-    if self.index >= self.count {
-      None
+  /// Set the value of the widget.
+  pub fn set_value(&self, value: &str) -> Result<()> {
+    unsafe { self.set_raw_value::<c_char>(to_c_string!(value)) }
+  }
+
+  fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
+    f.field("value", self.value().fmt_res());
+  }
+}
+
+impl RangeWidget {
+  /// Get the value of the widget.
+  pub fn value(&self) -> Result<f32> {
+    unsafe { self.raw_value::<f32>() }
+  }
+
+  /// Set the value of the widget.
+  pub fn set_value(&self, value: f32) -> Result<()> {
+    unsafe { self.set_raw_value::<f32>(&value) }
+  }
+
+  /// Get the range and increment step of the widget.
+  pub fn range_and_step(&self) -> Result<(RangeInclusive<f32>, f32)> {
+    try_gp_internal!(gp_widget_get_range(self.as_ptr(), &out min, &out max, &out step));
+    Ok((min..=max, step))
+  }
+
+  fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
+    let (range, step) = match self.range_and_step() {
+      Ok((range, step)) => (Some(range), Some(step)),
+      Err(_) => (None, None),
+    };
+    f.field("range", &range).field("step", &step).field("value", &self.value().fmt_res());
+  }
+}
+
+impl ToggleWidget {
+  /// Check if the widget is toggled.
+  pub fn is_toggled(&self) -> Result<Option<bool>> {
+    unsafe { self.raw_value::<c_int>() }.map(|value| match value {
+      0 => Some(false),
+      1 => Some(true),
+      _ => None,
+    })
+  }
+
+  /// Set the toggled state of the widget.
+  pub fn set_toggled(&self, value: bool) -> Result<()> {
+    unsafe { self.set_raw_value::<c_int>(&(value as _)) }
+  }
+
+  fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
+    f.field("toggled", self.is_toggled().fmt_res());
+  }
+}
+
+impl RadioWidget {
+  /// Get list of the available choices.
+  pub fn choices(&self) -> Result<Vec<String>> {
+    try_gp_internal!(let choice_count = gp_widget_count_choices(self.as_ptr()));
+
+    (0..choice_count)
+      .map(|i| {
+        try_gp_internal!(gp_widget_get_choice(self.as_ptr(), i, &out choice));
+        Ok(chars_to_string(choice))
+      })
+      .collect()
+  }
+
+  /// Get the current choice.
+  pub fn choice(&self) -> Result<String> {
+    Ok(chars_to_string(unsafe { self.raw_value::<*const c_char>()? }))
+  }
+
+  /// Set the current choice.
+  pub fn set_choice(&self, value: &str) -> Result<()> {
+    unsafe { self.set_raw_value::<c_char>(to_c_string!(value)) }
+  }
+
+  fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
+    f.field("choices", &MaybeListFmt(|| self.choices())).field("choice", self.choice().fmt_res());
+  }
+}
+
+impl DateWidget {
+  /// Get the widget's value as a UNIX timestamp.
+  pub fn timestamp(&self) -> Result<c_int> {
+    unsafe { self.raw_value::<c_int>() }
+  }
+
+  /// Set the widget's value as a UNIX timestamp.
+  pub fn set_timestamp(&self, value: c_int) -> Result<()> {
+    unsafe { self.set_raw_value::<c_int>(&value) }
+  }
+
+  fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
+    f.field("timestamp", self.timestamp().fmt_res());
+  }
+}
+
+impl ButtonWidget {
+  /// Press the button.
+  pub fn press(&self, camera: &Camera) -> Result<()> {
+    let callback = unsafe { self.raw_value::<libgphoto2_sys::CameraWidgetCallback>() }?
+      .ok_or("Button without callback")?;
+    let status = unsafe { callback(camera.camera, self.as_ptr(), camera.context) };
+    if status < 0 {
+      Err(Error::new(status, None))
     } else {
-      let child = self.parent_widget.get_child(self.index).ok();
-      self.index += 1;
-
-      child
+      Ok(())
     }
+  }
+
+  fn fmt_fields(&self, _f: &mut fmt::DebugStruct) {}
+}
+
+impl Widget {
+  pub(crate) fn new_shared(widget: *mut libgphoto2_sys::CameraWidget) -> Result<Self> {
+    unsafe {
+      libgphoto2_sys::gp_widget_ref(widget);
+    }
+
+    Self::new_owned(widget)
   }
 }


### PR DESCRIPTION
This adds typed variations of widgets, so that it's impossible to pass incompatible value to a widget set_value, or try to access children on non-grouping widget and so on.

More specifically, this adds `widget::{GroupWidget, TextWidget, RangeWidget, ToggleWidget, RadioWidget, ButtonWidget}` types that each provides its own strongly typed API.

All those types inherit from `WidgetBase` that also provides core properties such as `id`, `name` and so on that can be accessed on any of strongly widget types as well.

There is also a `Widget` enum that is simply a container for arbitrary widget and can be matched against or converted into the specific widget type.

Finally, top-level function `config` was updated to return `GroupWidget` and `config_key` has a generic param that allows to immediately specify which widget type you want (since in most cases, when user provides a hardcoded widget name, they likely know its type as well).

This is fairly big change, but I think the ergonomics of statically typed widgets are worth it.