### PR TITLE
Fix file info bitmasks; make all file info lazy

### DIFF
--- a/libgphoto2-sys/Cargo.toml
+++ b/libgphoto2-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libgphoto2_sys"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "System bindings to libgphoto2"
 repository = "https://git.maxicarlos.de/maxicarlos08/gphoto2-rs"

--- a/libgphoto2-sys/src/build.rs
+++ b/libgphoto2-sys/src/build.rs
@@ -13,7 +13,10 @@ fn main() {
     .generate_comments(true)
     .parse_callbacks(Box::new(bindgen::CargoCallbacks))
     .default_enum_style(bindgen::EnumVariation::Rust { non_exhaustive: false })
-    .bitfield_enum("^Camera(FilePermissions|(File|Folder)?Operation)$")
+    .bitfield_enum("CameraFilePermissions")
+    .bitfield_enum("CameraFileStatus")
+    .bitfield_enum("Camera(File|Folder)?Operation")
+    .bitfield_enum("Camera(File|Storage)InfoFields")
     .generate()
     .expect("Unable to generate bindings");
 


### PR DESCRIPTION
Like in #9, I noticed few more bitmasks - around file info - that were incorrectly bound as Rust enums in libgphoto2-sys, causing UB.

While fixing it, I also decided to make all file info expose consistent lazy interface where fields are converted & returned in individual methods instead of entire structure at once.

I've also wrapped the top-level FileInfo into a Box, since it's almost 300 bytes and can be expensive to keep & move around on stack.