### PR TITLE
Make some methods infallible

### DIFF
--- a/examples/bulb_capture.rs
+++ b/examples/bulb_capture.rs
@@ -18,12 +18,12 @@ fn main() -> Result<()> {
 
   println!("Starting bulb capture");
 
-  bulb_setting.set_toggled(true)?;
+  bulb_setting.set_toggled(true);
   camera.set_config(&bulb_setting)?;
 
   sleep(Duration::from_secs(2));
 
-  bulb_setting.set_toggled(false)?;
+  bulb_setting.set_toggled(false);
   camera.set_config(&bulb_setting)?;
 
   let mut retry = 0;

--- a/examples/camera_info.rs
+++ b/examples/camera_info.rs
@@ -4,7 +4,7 @@ fn main() -> Result<()> {
   let camera = Context::new()?.autodetect_camera()?;
 
   println!("==== SUMMARY   ====\n{}", camera.summary()?);
-  println!("==== ABILITIES ====\n{:#?}", camera.abilities()?);
+  println!("==== ABILITIES ====\n{:#?}", camera.abilities());
   println!("==== STORAGES  ====");
 
   let storages = camera.storages()?;

--- a/examples/drop_camera.rs
+++ b/examples/drop_camera.rs
@@ -6,11 +6,11 @@ fn main() -> Result<()> {
   let camera = Context::new()?.autodetect_camera()?;
 
   let widget = camera.config()?;
-  let abilities = camera.abilities()?;
+  let abilities = camera.abilities();
 
   drop(camera);
 
-  widget.children_count()?;
+  widget.children_count();
   println!("{:?}", abilities);
 
   Ok(())

--- a/examples/list_cameras.rs
+++ b/examples/list_cameras.rs
@@ -3,7 +3,7 @@ use gphoto2::{Context, Result};
 fn main() -> Result<()> {
   let cameras = Context::new()?.list_cameras()?;
 
-  println!("Available cameras:\n{:#?}", cameras.to_vec());
+  println!("Available cameras:\n{:#?}", cameras);
 
   Ok(())
 }

--- a/examples/list_cameras.rs
+++ b/examples/list_cameras.rs
@@ -1,9 +1,13 @@
+use gphoto2::list::CameraDescriptor;
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
-  let cameras = Context::new()?.list_cameras()?;
+  let context = Context::new()?;
 
-  println!("Available cameras:\n{:#?}", cameras);
+  println!("Available cameras:");
+  for CameraDescriptor { model, port } in context.list_cameras()? {
+    println!("  {} on port {}", model, port);
+  }
 
   Ok(())
 }

--- a/examples/list_cameras.rs
+++ b/examples/list_cameras.rs
@@ -3,7 +3,7 @@ use gphoto2::{Context, Result};
 fn main() -> Result<()> {
   let cameras = Context::new()?.list_cameras()?;
 
-  println!("Available cameras:\n{:#?}", cameras.to_vec()?);
+  println!("Available cameras:\n{:#?}", cameras.to_vec());
 
   Ok(())
 }

--- a/examples/select_camera.rs
+++ b/examples/select_camera.rs
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
   let context = Context::new()?;
 
   let camera_list = context.list_cameras()?;
-  let camera_list = camera_list.to_vec()?;
+  let camera_list = camera_list.to_vec();
 
   if let Some((camera, port)) = camera_list.iter().find(|(name, _)| name == &camera_name) {
     let _camera = context.get_camera(&camera.to_owned(), &port.to_owned())?;

--- a/examples/select_camera.rs
+++ b/examples/select_camera.rs
@@ -9,15 +9,12 @@ fn main() -> Result<()> {
 
   let context = Context::new()?;
 
-  let camera_list = context.list_cameras()?;
+  let camera_desc = context
+    .list_cameras()?
+    .find(|desc| desc.model == camera_name)
+    .ok_or_else(|| format!("Could not find camera with name '{}'", camera_name))?;
 
-  if let Some((camera, port)) = camera_list.iter().find(|(name, _)| name == &camera_name) {
-    let _camera = context.get_camera(&camera, &port)?;
-
-    println!("Found camera {}!", camera_name);
-  } else {
-    Err(format!("Could not find camera with name '{}'", camera_name).as_str())?;
-  }
+  let _camera = context.get_camera(&camera_desc)?;
 
   Ok(())
 }

--- a/examples/select_camera.rs
+++ b/examples/select_camera.rs
@@ -10,10 +10,9 @@ fn main() -> Result<()> {
   let context = Context::new()?;
 
   let camera_list = context.list_cameras()?;
-  let camera_list = camera_list.to_vec();
 
   if let Some((camera, port)) = camera_list.iter().find(|(name, _)| name == &camera_name) {
-    let _camera = context.get_camera(&camera.to_owned(), &port.to_owned())?;
+    let _camera = context.get_camera(&camera, &port)?;
 
     println!("Found camera {}!", camera_name);
   } else {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -149,7 +149,7 @@ impl Camera {
 
     try_gp_internal!(gp_camera_get_abilities(self.camera, inner.as_mut_ptr()).unwrap());
 
-    Ok(Abilities { inner: unsafe { inner.assume_init() } })
+    Abilities { inner: unsafe { inner.assume_init() } }
   }
 
   /// Summary of the cameras model, settings, capabilities, etc.

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -51,7 +51,7 @@ pub enum CameraEvent {
 /// let camera = context.autodetect_camera()?;
 ///
 /// // Get some basic information about the camera
-/// println!("Camera abilities: {:?}", camera.abilities()?);
+/// println!("Camera abilities: {:?}", camera.abilities());
 /// println!("Camera summary: {}", camera.summary()?);
 ///
 /// // Capture an image
@@ -129,7 +129,7 @@ impl Camera {
   /// let camera = context.autodetect_camera()?;
   ///
   /// let image_preview = camera.capture_preview()?;
-  /// println!("Preview name: {}", image_preview.name()?);
+  /// println!("Preview name: {}", image_preview.name());
   /// # Ok(())
   /// # }
   /// ```

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -144,17 +144,17 @@ impl Camera {
   /// Get the camera's [`Abilities`]
   ///
   /// The abilities contain information about the driver used, permissions and camera model
-  pub fn abilities(&self) -> Result<Abilities> {
+  pub fn abilities(&self) -> Abilities {
     let mut inner = UninitBox::uninit();
 
-    try_gp_internal!(gp_camera_get_abilities(self.camera, inner.as_mut_ptr()));
+    try_gp_internal!(gp_camera_get_abilities(self.camera, inner.as_mut_ptr()).unwrap());
 
     Ok(Abilities { inner: unsafe { inner.assume_init() } })
   }
 
   /// Summary of the cameras model, settings, capabilities, etc.
   pub fn summary(&self) -> Result<String> {
-    try_gp_internal!(gp_camera_get_summary(self.camera, &out summary, self.context));
+    try_gp_internal!(gp_camera_get_summary(self.camera, &out summary, self.context).unwrap());
 
     Ok(char_slice_to_cow(&summary.text).into_owned())
   }
@@ -261,7 +261,7 @@ impl Camera {
   pub fn config(&self) -> Result<GroupWidget> {
     try_gp_internal!(gp_camera_get_config(self.camera, &out root_widget, self.context));
 
-    Widget::new_owned(root_widget)?.try_into::<GroupWidget>()
+    Widget::new_owned(root_widget).try_into::<GroupWidget>()
   }
 
   /// Get a single configuration by name.
@@ -278,7 +278,7 @@ impl Camera {
       self.context
     ));
 
-    Ok(Widget::new_owned(widget)?.try_into()?)
+    Ok(Widget::new_owned(widget).try_into()?)
   }
 
   /// Apply a full config object to the camera.
@@ -292,7 +292,7 @@ impl Camera {
   pub fn set_config(&self, config: &WidgetBase) -> Result<()> {
     try_gp_internal!(gp_camera_set_single_config(
       self.camera,
-      to_c_string!(config.name()?),
+      to_c_string!(config.name()),
       config.inner,
       self.context
     ));

--- a/src/error.rs
+++ b/src/error.rs
@@ -157,7 +157,6 @@ impl error::Error for Error {}
 ///
 /// If the return type is less than 0, an error is returned,
 /// otherwise the result of the function
-#[macro_export]
 macro_rules! try_gp_internal {
   (@ $unwrap:tt $status:tt [ $($out:ident)* ] $func:ident ( $($args:tt)* ) &out $new_out:ident $($rest:tt)*) => {
     try_gp_internal!(@ $unwrap $status [ $($out)* $new_out ] $func ( $($args)* $new_out.as_mut_ptr() ) $($rest)*)
@@ -191,3 +190,5 @@ macro_rules! try_gp_internal {
     try_gp_internal!(let _ = $func ( $($args)* ) $($unwrap)*)
   };
 }
+
+pub(crate) use try_gp_internal;

--- a/src/file.rs
+++ b/src/file.rs
@@ -249,16 +249,16 @@ impl CameraFile {
   }
 
   /// File name
-  pub fn name(&self) -> Result<String> {
-    try_gp_internal!(gp_file_get_name(self.inner, &out file_name));
+  pub fn name(&self) -> String {
+    try_gp_internal!(gp_file_get_name(self.inner, &out file_name).unwrap());
 
-    Ok(chars_to_string(file_name))
+    chars_to_string(file_name)
   }
 
   /// File mime type
-  pub fn mime(&self) -> Result<String> {
-    try_gp_internal!(gp_file_get_mime_type(self.inner, &out mime));
+  pub fn mime(&self) -> String {
+    try_gp_internal!(gp_file_get_mime_type(self.inner, &out mime).unwrap());
 
-    Ok(chars_to_string(mime))
+    chars_to_string(mime)
   }
 }

--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -3,7 +3,7 @@
 use crate::{
   file::{CameraFile, FileType},
   helper::{bitflags, char_slice_to_cow, to_c_string, UninitBox},
-  list::CameraList,
+  list::{CameraList, FileListIter},
   try_gp_internal, Camera, Result,
 };
 use std::{borrow::Cow, ffi};
@@ -302,7 +302,7 @@ impl<'a> CameraFS<'a> {
   }
 
   /// List files in a folder
-  pub fn ls_files(&self, folder: &str) -> Result<Vec<String>> {
+  pub fn ls_files(&self, folder: &str) -> Result<FileListIter> {
     let file_list = CameraList::new()?;
 
     try_gp_internal!(gp_camera_folder_list_files(
@@ -312,11 +312,11 @@ impl<'a> CameraFS<'a> {
       self.camera.context
     ));
 
-    Ok(file_list.iter().map(|(name, _)| name).collect())
+    Ok(FileListIter::new(file_list))
   }
 
   /// List folders in a folder
-  pub fn ls_folders(&self, folder: &str) -> Result<Vec<String>> {
+  pub fn ls_folders(&self, folder: &str) -> Result<FileListIter> {
     let folder_list = CameraList::new()?;
 
     try_gp_internal!(gp_camera_folder_list_folders(
@@ -326,7 +326,7 @@ impl<'a> CameraFS<'a> {
       self.camera.context
     ));
 
-    Ok(folder_list.iter().map(|(name, _)| name).collect())
+    Ok(FileListIter::new(folder_list))
   }
 
   /// Creates a new folder

--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -312,7 +312,7 @@ impl<'a> CameraFS<'a> {
       self.camera.context
     ));
 
-    Ok(file_list.to_vec()?.into_iter().map(|(name, _)| name).collect())
+    Ok(file_list.to_vec().into_iter().map(|(name, _)| name).collect())
   }
 
   /// List folders in a folder
@@ -326,7 +326,7 @@ impl<'a> CameraFS<'a> {
       self.camera.context
     ));
 
-    Ok(folder_list.to_vec()?.into_iter().map(|(name, _)| name).collect())
+    Ok(folder_list.to_vec().into_iter().map(|(name, _)| name).collect())
   }
 
   /// Creates a new folder

--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -312,7 +312,7 @@ impl<'a> CameraFS<'a> {
       self.camera.context
     ));
 
-    Ok(file_list.to_vec().into_iter().map(|(name, _)| name).collect())
+    Ok(file_list.iter().map(|(name, _)| name).collect())
   }
 
   /// List folders in a folder
@@ -326,7 +326,7 @@ impl<'a> CameraFS<'a> {
       self.camera.context
     ));
 
-    Ok(folder_list.to_vec().into_iter().map(|(name, _)| name).collect())
+    Ok(folder_list.iter().map(|(name, _)| name).collect())
   }
 
   /// Creates a new folder

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,6 +1,3 @@
-use crate::Result;
-use std::fmt::Debug;
-use std::mem::MaybeUninit;
 use std::{borrow::Cow, ffi, os::raw::c_char};
 
 pub fn char_slice_to_cow(chars: &[c_char]) -> Cow<'_, str> {
@@ -9,19 +6,6 @@ pub fn char_slice_to_cow(chars: &[c_char]) -> Cow<'_, str> {
 
 pub fn chars_to_string(chars: *const c_char) -> String {
   unsafe { String::from_utf8_lossy(ffi::CStr::from_ptr(chars).to_bytes()) }.into_owned()
-}
-
-pub trait FmtResult {
-  fn fmt_res(&self) -> &dyn Debug;
-}
-
-impl<T: Debug> FmtResult for Result<T> {
-  fn fmt_res(&self) -> &dyn Debug {
-    match self {
-      Ok(v) => v,
-      Err(e) => e,
-    }
-  }
 }
 
 pub struct UninitBox<T> {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,3 +1,4 @@
+use std::mem::MaybeUninit;
 use std::{borrow::Cow, ffi, os::raw::c_char};
 
 pub fn char_slice_to_cow(chars: &[c_char]) -> Cow<'_, str> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub mod list;
 pub mod port;
 pub mod widget;
 
+use self::error::try_gp_internal;
+
 #[doc(inline)]
 pub use crate::{
   camera::Camera,

--- a/src/list.rs
+++ b/src/list.rs
@@ -4,6 +4,7 @@ use crate::{
   helper::{as_ref, chars_to_string},
   try_gp_internal, Result,
 };
+use std::os::raw::c_int;
 
 /// List of string tuples
 pub struct CameraList {
@@ -27,17 +28,71 @@ impl CameraList {
     Ok(Self { inner: list })
   }
 
-  /// Converts the internal gphoto list to a rust vec
-  pub fn to_vec(&self) -> Vec<(String, String)> {
-    let length = unsafe { libgphoto2_sys::gp_list_count(self.inner) };
+  /// Get length of the list.
+  pub fn len(&self) -> usize {
+    unsafe { libgphoto2_sys::gp_list_count(self.inner) as usize }
+  }
 
-    (0..length)
-      .map(|list_index| {
-        try_gp_internal!(gp_list_get_name(self.inner, list_index, &out name).unwrap());
-        try_gp_internal!(gp_list_get_value(self.inner, list_index, &out value).unwrap());
+  /// Check if the list is empty.
+  pub fn is_empty(&self) -> bool {
+    self.len() == 0
+  }
 
-        (chars_to_string(name), chars_to_string(value))
-      })
-      .collect()
+  /// Get the name and value of the list item at the given index.
+  pub fn get_name_value(&self, index: usize) -> Result<(String, String)> {
+    try_gp_internal!(gp_list_get_name(self.inner, index as c_int, &out name));
+    try_gp_internal!(gp_list_get_value(self.inner, index as c_int, &out value));
+
+    Ok((chars_to_string(name), chars_to_string(value)))
+  }
+
+  /// Get a referential iterator.
+  pub fn iter(&self) -> CameraListIter<'_> {
+    self.into_iter()
+  }
+}
+
+impl std::fmt::Debug for CameraList {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_list().entries(self.iter()).finish()
+  }
+}
+
+impl<'a> IntoIterator for &'a CameraList {
+  type Item = (String, String);
+  type IntoIter = CameraListIter<'a>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    CameraListIter::new(self)
+  }
+}
+
+/// Iterator for [`CameraList`]
+pub struct CameraListIter<'a> {
+  list: &'a CameraList,
+  range: std::ops::Range<usize>,
+}
+
+impl<'a> CameraListIter<'a> {
+  fn new(list: &'a CameraList) -> Self {
+    Self { range: 0..list.len(), list }
+  }
+}
+
+impl Iterator for CameraListIter<'_> {
+  type Item = (String, String);
+
+  fn next(&mut self) -> Option<Self::Item> {
+    self.range.next().map(|i| self.list.get_name_value(i).unwrap())
+  }
+
+  fn size_hint(&self) -> (usize, Option<usize>) {
+    self.range.size_hint()
+  }
+}
+
+impl ExactSizeIterator for CameraListIter<'_> {
+  fn len(&self) -> usize {
+    self.range.len()
   }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -28,18 +28,16 @@ impl CameraList {
   }
 
   /// Converts the internal gphoto list to a rust vec
-  pub fn to_vec(&self) -> Result<Vec<(String, String)>> {
+  pub fn to_vec(&self) -> Vec<(String, String)> {
     let length = unsafe { libgphoto2_sys::gp_list_count(self.inner) };
 
-    let mut res = Vec::with_capacity(length as usize);
+    (0..length)
+      .map(|list_index| {
+        try_gp_internal!(gp_list_get_name(self.inner, list_index, &out name).unwrap());
+        try_gp_internal!(gp_list_get_value(self.inner, list_index, &out value).unwrap());
 
-    for list_index in 0..length {
-      try_gp_internal!(gp_list_get_name(self.inner, list_index, &out name));
-      try_gp_internal!(gp_list_get_value(self.inner, list_index, &out value));
-
-      res.push((chars_to_string(name), chars_to_string(value)));
-    }
-
-    Ok(res)
+        (chars_to_string(name), chars_to_string(value))
+      })
+      .collect()
   }
 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -17,7 +17,7 @@
 //! ```
 
 use crate::{
-  helper::{as_ref, chars_to_string, FmtResult},
+  helper::{as_ref, chars_to_string},
   try_gp_internal, Result,
 };
 use std::fmt;
@@ -76,9 +76,9 @@ impl From<libgphoto2_sys::GPPortInfo> for PortInfo {
 impl fmt::Debug for PortInfo {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.debug_struct("PortInfo")
-      .field("name", self.name().fmt_res())
-      .field("path", self.path().fmt_res())
-      .field("port_type", self.port_type().fmt_res())
+      .field("name", &self.name())
+      .field("path", &self.path())
+      .field("port_type", &self.port_type())
       .finish()
   }
 }
@@ -106,24 +106,24 @@ impl PortType {
 
 impl PortInfo {
   /// Name of the port
-  pub fn name(&self) -> Result<String> {
-    try_gp_internal!(gp_port_info_get_name(self.inner, &out name));
+  pub fn name(&self) -> String {
+    try_gp_internal!(gp_port_info_get_name(self.inner, &out name).unwrap());
 
-    Ok(chars_to_string(name))
+    chars_to_string(name)
   }
 
   /// Path of the port
-  pub fn path(&self) -> Result<String> {
-    try_gp_internal!(gp_port_info_get_path(self.inner, &out path));
+  pub fn path(&self) -> String {
+    try_gp_internal!(gp_port_info_get_path(self.inner, &out path).unwrap());
 
-    Ok(chars_to_string(path))
+    chars_to_string(path)
   }
 
   /// [Port type](PortType)
-  pub fn port_type(&self) -> Result<Option<PortType>> {
-    try_gp_internal!(gp_port_info_get_type(self.inner, &out port_type));
+  pub fn port_type(&self) -> Option<PortType> {
+    try_gp_internal!(gp_port_info_get_type(self.inner, &out port_type).unwrap());
 
-    Ok(PortType::new(port_type))
+    PortType::new(port_type)
   }
 }
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -433,12 +433,8 @@ impl ButtonWidget {
   pub fn press(&self, camera: &Camera) -> Result<()> {
     let callback = unsafe { self.raw_value::<libgphoto2_sys::CameraWidgetCallback>() }
       .ok_or("Button without callback")?;
-    let status = unsafe { callback(camera.camera, self.as_ptr(), camera.context) };
-    if status < 0 {
-      Err(Error::new(status, None))
-    } else {
-      Ok(())
-    }
+    Error::check(unsafe { callback(camera.camera, self.as_ptr(), camera.context) })?;
+    Ok(())
   }
 
   fn fmt_fields(&self, _f: &mut fmt::DebugStruct) {}

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -16,7 +16,7 @@
 //! ```
 
 use crate::{
-  helper::{as_ref, chars_to_string, to_c_string, FmtResult},
+  helper::{as_ref, chars_to_string, to_c_string},
   try_gp_internal, Camera, Error, Result,
 };
 use std::{
@@ -71,60 +71,55 @@ impl WidgetBase {
   }
 
   /// Get exact widget type.
-  fn ty(&self) -> Result<libgphoto2_sys::CameraWidgetType> {
-    try_gp_internal!(gp_widget_get_type(self.inner, &out widget_type));
-    Ok(widget_type)
+  fn ty(&self) -> libgphoto2_sys::CameraWidgetType {
+    try_gp_internal!(gp_widget_get_type(self.inner, &out widget_type).unwrap());
+    widget_type
   }
 
   /// If true, the widget cannot be written
-  pub fn readonly(&self) -> Result<bool> {
-    try_gp_internal!(gp_widget_get_readonly(self.inner, &out readonly));
-
-    Ok(readonly == 1)
+  pub fn readonly(&self) -> bool {
+    try_gp_internal!(gp_widget_get_readonly(self.inner, &out readonly).unwrap());
+    readonly == 1
   }
 
   /// Get the widget label
-  pub fn label(&self) -> Result<String> {
-    try_gp_internal!(gp_widget_get_label(self.inner, &out label));
-
-    Ok(chars_to_string(label))
+  pub fn label(&self) -> String {
+    try_gp_internal!(gp_widget_get_label(self.inner, &out label).unwrap());
+    chars_to_string(label)
   }
 
   /// Get the widget name
-  pub fn name(&self) -> Result<String> {
-    try_gp_internal!(gp_widget_get_name(self.inner, &out name));
-    Ok(chars_to_string(name))
+  pub fn name(&self) -> String {
+    try_gp_internal!(gp_widget_get_name(self.inner, &out name).unwrap());
+    chars_to_string(name)
   }
 
   /// Get the widget id
-  pub fn id(&self) -> Result<i32> {
-    try_gp_internal!(gp_widget_get_id(self.inner, &out id));
-
-    Ok(id)
+  pub fn id(&self) -> i32 {
+    try_gp_internal!(gp_widget_get_id(self.inner, &out id).unwrap());
+    id
   }
 
   /// Get information about the widget
-  pub fn info(&self) -> Result<String> {
-    try_gp_internal!(gp_widget_get_info(self.inner, &out info));
-
-    Ok(chars_to_string(info))
+  pub fn info(&self) -> String {
+    try_gp_internal!(gp_widget_get_info(self.inner, &out info).unwrap());
+    chars_to_string(info)
   }
 
   fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
-    f.field("id", self.id().fmt_res())
-      .field("name", self.name().fmt_res())
-      .field("label", self.label().fmt_res())
-      .field("readonly", self.readonly().fmt_res());
+    f.field("id", &self.id())
+      .field("name", &self.name())
+      .field("label", &self.label())
+      .field("readonly", &self.readonly());
   }
 
-  unsafe fn raw_value<T>(&self) -> Result<T> {
-    try_gp_internal!(gp_widget_get_value(self.inner, &out value as *mut T as *mut c_void));
-    Ok(value)
+  unsafe fn raw_value<T>(&self) -> T {
+    try_gp_internal!(gp_widget_get_value(self.inner, &out value as *mut T as *mut c_void).unwrap());
+    value
   }
 
-  unsafe fn set_raw_value<T>(&self, value: *const T) -> Result<()> {
-    try_gp_internal!(gp_widget_set_value(self.inner, value.cast::<c_void>()));
-    Ok(())
+  unsafe fn set_raw_value<T>(&self, value: *const T) {
+    try_gp_internal!(gp_widget_set_value(self.inner, value.cast::<c_void>()).unwrap());
   }
 }
 
@@ -157,12 +152,12 @@ macro_rules! typed_widgets {
     }
 
     impl Widget {
-      pub(crate) fn new_owned(widget: *mut libgphoto2_sys::CameraWidget) -> Result<Self> {
+      pub(crate) fn new_owned(widget: *mut libgphoto2_sys::CameraWidget) -> Self {
         let inner = WidgetBase { inner: widget };
 
-        Ok(match inner.ty()? {
+        match inner.ty() {
           $($(libgphoto2_sys::CameraWidgetType::$gp_name)|+ => Widget::$variant($name { inner }),)*
-        })
+        }
       }
     }
 
@@ -265,16 +260,13 @@ typed_widgets!(
 /// Helper that prints `...` when using `{:?}` or the given list when using `{:#?}`.
 struct MaybeListFmt<F>(F);
 
-impl<Iter: IntoIterator, F: Fn() -> Result<Iter>> fmt::Debug for MaybeListFmt<F>
+impl<Iter: IntoIterator, F: Fn() -> Iter> fmt::Debug for MaybeListFmt<F>
 where
   Iter::Item: fmt::Debug,
 {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     if f.alternate() {
-      match (self.0)() {
-        Ok(iter) => f.debug_list().entries(iter).finish(),
-        Err(err) => err.fmt(f),
-      }
+      f.debug_list().entries((self.0)()).finish()
     } else {
       f.write_str("...")
     }
@@ -283,42 +275,42 @@ where
 
 impl GroupWidget {
   /// Creates a new [`WidgetIterator`]
-  pub fn children_iter(&self) -> Result<WidgetIterator<'_>> {
-    Ok(WidgetIterator { parent_widget: self, range: 0..self.children_count()? })
+  pub fn children_iter(&self) -> WidgetIterator<'_> {
+    WidgetIterator { parent_widget: self, range: 0..self.children_count() }
   }
 
   /// Counts the children of the widget
-  pub fn children_count(&self) -> Result<usize> {
-    try_gp_internal!(let count = gp_widget_count_children(self.as_ptr()));
-    Ok(count as usize)
+  pub fn children_count(&self) -> usize {
+    try_gp_internal!(let count = gp_widget_count_children(self.as_ptr()).unwrap());
+    count as usize
   }
 
   /// Gets a child by its index
   pub fn get_child(&self, index: usize) -> Result<Widget> {
     try_gp_internal!(gp_widget_get_child(self.as_ptr(), index as c_int, &out child));
 
-    Widget::new_shared(child)
+    Ok(Widget::new_shared(child))
   }
 
   /// Get a child by its id
   pub fn get_child_by_id(&self, id: usize) -> Result<Widget> {
     try_gp_internal!(gp_widget_get_child_by_id(self.as_ptr(), id as c_int, &out child));
 
-    Widget::new_shared(child)
+    Ok(Widget::new_shared(child))
   }
 
   /// Get a child by its label
   pub fn get_child_by_label(&self, label: &str) -> Result<Widget> {
     try_gp_internal!(gp_widget_get_child_by_label(self.as_ptr(), to_c_string!(label), &out child));
 
-    Widget::new_shared(child)
+    Ok(Widget::new_shared(child))
   }
 
   /// Get a child by its name
   pub fn get_child_by_name(&self, name: &str) -> Result<Widget> {
     try_gp_internal!(gp_widget_get_child_by_name(self.as_ptr(), to_c_string!(name), &out child));
 
-    Widget::new_shared(child)
+    Ok(Widget::new_shared(child))
   }
 
   fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
@@ -328,114 +320,118 @@ impl GroupWidget {
 
 impl TextWidget {
   /// Get the value of the widget.
-  pub fn value(&self) -> Result<String> {
-    Ok(chars_to_string(unsafe { self.raw_value::<*const c_char>()? }))
+  pub fn value(&self) -> String {
+    chars_to_string(unsafe { self.raw_value::<*const c_char>() })
   }
 
   /// Set the value of the widget.
   pub fn set_value(&self, value: &str) -> Result<()> {
-    unsafe { self.set_raw_value::<c_char>(to_c_string!(value)) }
+    unsafe {
+      self.set_raw_value::<c_char>(to_c_string!(value));
+    }
+    Ok(())
   }
 
   fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
-    f.field("value", self.value().fmt_res());
+    f.field("value", &self.value());
   }
 }
 
 impl RangeWidget {
   /// Get the value of the widget.
-  pub fn value(&self) -> Result<f32> {
+  pub fn value(&self) -> f32 {
     unsafe { self.raw_value::<f32>() }
   }
 
   /// Set the value of the widget.
-  pub fn set_value(&self, value: f32) -> Result<()> {
+  pub fn set_value(&self, value: f32) {
     unsafe { self.set_raw_value::<f32>(&value) }
   }
 
   /// Get the range and increment step of the widget.
-  pub fn range_and_step(&self) -> Result<(RangeInclusive<f32>, f32)> {
-    try_gp_internal!(gp_widget_get_range(self.as_ptr(), &out min, &out max, &out step));
-    Ok((min..=max, step))
+  pub fn range_and_step(&self) -> (RangeInclusive<f32>, f32) {
+    try_gp_internal!(gp_widget_get_range(self.as_ptr(), &out min, &out max, &out step).unwrap());
+    (min..=max, step)
   }
 
   fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
-    let (range, step) = match self.range_and_step() {
-      Ok((range, step)) => (Some(range), Some(step)),
-      Err(_) => (None, None),
-    };
-    f.field("range", &range).field("step", &step).field("value", &self.value().fmt_res());
+    let (range, step) = self.range_and_step();
+    f.field("range", &range).field("step", &step).field("value", &self.value());
   }
 }
 
 impl ToggleWidget {
   /// Check if the widget is toggled.
-  pub fn is_toggled(&self) -> Result<Option<bool>> {
-    unsafe { self.raw_value::<c_int>() }.map(|value| match value {
+  pub fn is_toggled(&self) -> Option<bool> {
+    let value = unsafe { self.raw_value::<c_int>() };
+    match value {
       0 => Some(false),
       1 => Some(true),
       _ => None,
-    })
+    }
   }
 
   /// Set the toggled state of the widget.
-  pub fn set_toggled(&self, value: bool) -> Result<()> {
+  pub fn set_toggled(&self, value: bool) {
     unsafe { self.set_raw_value::<c_int>(&(value as _)) }
   }
 
   fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
-    f.field("toggled", self.is_toggled().fmt_res());
+    f.field("toggled", &self.is_toggled());
   }
 }
 
 impl RadioWidget {
   /// Get list of the available choices.
-  pub fn choices(&self) -> Result<Vec<String>> {
-    try_gp_internal!(let choice_count = gp_widget_count_choices(self.as_ptr()));
+  pub fn choices(&self) -> Vec<String> {
+    try_gp_internal!(let choice_count = gp_widget_count_choices(self.as_ptr()).unwrap());
 
     (0..choice_count)
       .map(|i| {
-        try_gp_internal!(gp_widget_get_choice(self.as_ptr(), i, &out choice));
-        Ok(chars_to_string(choice))
+        try_gp_internal!(gp_widget_get_choice(self.as_ptr(), i, &out choice).unwrap());
+        chars_to_string(choice)
       })
       .collect()
   }
 
   /// Get the current choice.
-  pub fn choice(&self) -> Result<String> {
-    Ok(chars_to_string(unsafe { self.raw_value::<*const c_char>()? }))
+  pub fn choice(&self) -> String {
+    chars_to_string(unsafe { self.raw_value::<*const c_char>() })
   }
 
   /// Set the current choice.
   pub fn set_choice(&self, value: &str) -> Result<()> {
-    unsafe { self.set_raw_value::<c_char>(to_c_string!(value)) }
+    unsafe {
+      self.set_raw_value::<c_char>(to_c_string!(value));
+    }
+    Ok(())
   }
 
   fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
-    f.field("choices", &MaybeListFmt(|| self.choices())).field("choice", self.choice().fmt_res());
+    f.field("choices", &MaybeListFmt(|| self.choices())).field("choice", &self.choice());
   }
 }
 
 impl DateWidget {
   /// Get the widget's value as a UNIX timestamp.
-  pub fn timestamp(&self) -> Result<c_int> {
+  pub fn timestamp(&self) -> c_int {
     unsafe { self.raw_value::<c_int>() }
   }
 
   /// Set the widget's value as a UNIX timestamp.
-  pub fn set_timestamp(&self, value: c_int) -> Result<()> {
+  pub fn set_timestamp(&self, value: c_int) {
     unsafe { self.set_raw_value::<c_int>(&value) }
   }
 
   fn fmt_fields(&self, f: &mut fmt::DebugStruct) {
-    f.field("timestamp", self.timestamp().fmt_res());
+    f.field("timestamp", &self.timestamp());
   }
 }
 
 impl ButtonWidget {
   /// Press the button.
   pub fn press(&self, camera: &Camera) -> Result<()> {
-    let callback = unsafe { self.raw_value::<libgphoto2_sys::CameraWidgetCallback>() }?
+    let callback = unsafe { self.raw_value::<libgphoto2_sys::CameraWidgetCallback>() }
       .ok_or("Button without callback")?;
     let status = unsafe { callback(camera.camera, self.as_ptr(), camera.context) };
     if status < 0 {
@@ -449,7 +445,7 @@ impl ButtonWidget {
 }
 
 impl Widget {
-  pub(crate) fn new_shared(widget: *mut libgphoto2_sys::CameraWidget) -> Result<Self> {
+  pub(crate) fn new_shared(widget: *mut libgphoto2_sys::CameraWidget) -> Self {
     unsafe {
       libgphoto2_sys::gp_widget_ref(widget);
     }


### PR DESCRIPTION
While technically all functions in libgphoto2 return status code,
a lot of them are simple getters that always return GP_OK unless you
pass null pointer or such.

As long as our bindings are correct, this should never happen in our
Rust code, and if it does, it's an actual bug in our code and can be
better represented by a panic.

For most users, this should make consumption of such getters simpler.

Additionally, various lists were converted from structs and Vecs into iterators, which allow users themselves to choose how to process them lazily.