### PR TITLE
Use more precise integer types

### DIFF
--- a/src/abilities.rs
+++ b/src/abilities.rs
@@ -28,15 +28,15 @@ pub struct Abilities {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UsbInfo {
   /// Vendor ID
-  pub vendor: usize,
+  pub vendor: u16,
   /// Product ID
-  pub product: usize,
+  pub product: u16,
   /// Device class
-  pub class: usize,
+  pub class: u8,
   /// Device subclass
-  pub subclass: usize,
+  pub subclass: u8,
   /// Device protocol
-  pub protocol: usize,
+  pub protocol: u8,
 }
 
 /// Status of the gphoto driver used
@@ -161,12 +161,13 @@ impl Abilities {
 
   /// Get USB information
   pub fn usb_info(&self) -> UsbInfo {
+    #[allow(clippy::as_conversions)]
     UsbInfo {
-      vendor: self.inner.usb_vendor as usize,
-      product: self.inner.usb_product as usize,
-      class: self.inner.usb_class as usize,
-      subclass: self.inner.usb_subclass as usize,
-      protocol: self.inner.usb_protocol as usize,
+      vendor: self.inner.usb_vendor as u16,
+      product: self.inner.usb_product as u16,
+      class: self.inner.usb_class as u8,
+      subclass: self.inner.usb_subclass as u8,
+      protocol: self.inner.usb_protocol as u8,
     }
   }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -188,7 +188,7 @@ impl Camera {
       std::slice::from_raw_parts(
         // We can cast pointer safely because StorageInfo is repr(transparent).
         storages_ptr.cast::<StorageInfo>(),
-        storages_len as usize,
+        storages_len.try_into()?,
       )
     };
 
@@ -215,7 +215,7 @@ impl Camera {
 
     try_gp_internal!(gp_camera_wait_for_event(
       self.camera,
-      duration_milliseconds as i32,
+      duration_milliseconds.try_into()?,
       &out event_type,
       &out event_data,
       self.context

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,9 +7,6 @@ use crate::helper::chars_to_string;
 /// Result type used in this library
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// i32 version of [`libgphoto2_sys::GP_OK`]
-pub const GP_OK: c_int = libgphoto2_sys::GP_OK as c_int;
-
 /// Error type
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ErrorKind {
@@ -110,8 +107,14 @@ impl From<std::io::Error> for Error {
 }
 
 impl From<std::ffi::NulError> for Error {
-  fn from(_: std::ffi::NulError) -> Self {
-    Self { error: libgphoto2_sys::GP_ERROR, info: Some("FFI: NulError".to_string()) }
+  fn from(err: std::ffi::NulError) -> Self {
+    Self { error: libgphoto2_sys::GP_ERROR_BAD_PARAMETERS, info: Some(err.to_string()) }
+  }
+}
+
+impl From<std::num::TryFromIntError> for Error {
+  fn from(err: std::num::TryFromIntError) -> Self {
+    Self { error: libgphoto2_sys::GP_ERROR, info: Some(err.to_string()) }
   }
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -243,7 +243,7 @@ impl CameraFile {
     try_gp_internal!(gp_file_get_data_and_size(self.inner, &out data, &out size)?);
 
     let data_slice: Box<[u8]> =
-      unsafe { std::slice::from_raw_parts(data as *const u8, size as usize) }.into();
+      unsafe { std::slice::from_raw_parts(data.cast::<u8>(), size.try_into()?) }.into();
 
     Ok(data_slice)
   }

--- a/src/filesys.rs
+++ b/src/filesys.rs
@@ -6,6 +6,7 @@ use crate::{
   list::{CameraList, FileListIter},
   try_gp_internal, Camera, Result,
 };
+use libgphoto2_sys::time_t;
 use std::{borrow::Cow, ffi};
 
 macro_rules! storage_info {
@@ -20,8 +21,9 @@ macro_rules! storage_info {
     impl $name {
       #[allow(dead_code)]
       pub(crate) fn from_inner_ref(ptr: &libgphoto2_sys::$inner_ty) -> &Self {
+        let ptr: *const _ = ptr;
         // Safe because of repr(transparent).
-        unsafe { &*(ptr as *const _ as *const Self) }
+        unsafe { &*ptr.cast::<Self>() }
       }
 
       $(
@@ -113,13 +115,13 @@ storage_info!(
     /// Status of the preview file
     status: FileStatus = GP_FILE_INFO_STATUS, info.status.into();
     /// Size of the preview file
-    size: usize = GP_FILE_INFO_SIZE, info.size as usize;
+    size: u64 = GP_FILE_INFO_SIZE, info.size;
     /// Mime type of the preview file
     mime_type: Cow<str> = GP_FILE_INFO_TYPE, char_slice_to_cow(&info.type_);
     /// Image width,
-    width: usize = GP_FILE_INFO_WIDTH, info.width as usize;
+    width: u32 = GP_FILE_INFO_WIDTH, info.width;
     /// Image height
-    height: usize = GP_FILE_INFO_HEIGHT, info.height as usize;
+    height: u32 = GP_FILE_INFO_HEIGHT, info.height;
   }
 );
 
@@ -129,17 +131,17 @@ storage_info!(
     /// Status of the file
     status: FileStatus = GP_FILE_INFO_STATUS, info.status.into();
     /// File size
-    size: usize = GP_FILE_INFO_SIZE, info.size as usize;
+    size: u64 = GP_FILE_INFO_SIZE, info.size;
     /// Mime type
     mime_type: Cow<str> = GP_FILE_INFO_TYPE, char_slice_to_cow(&info.type_);
     /// Image width
-    width: usize = GP_FILE_INFO_WIDTH, info.width as usize;
+    width: u32 = GP_FILE_INFO_WIDTH, info.width;
     /// Image height
-    height: usize = GP_FILE_INFO_HEIGHT, info.height as usize;
+    height: u32 = GP_FILE_INFO_HEIGHT, info.height;
     /// Image permissions
     permissions: FilePermissions = GP_FILE_INFO_PERMISSIONS, info.permissions.into();
-    /// File modification type
-    mtime: usize = GP_FILE_INFO_MTIME, info.mtime as usize;
+    /// File modification time
+    mtime: time_t = GP_FILE_INFO_MTIME, info.mtime;
   }
 );
 
@@ -149,7 +151,7 @@ storage_info!(
     /// Status of the audio file
     status: FileStatus = GP_FILE_INFO_STATUS, info.status.into();
     /// Size of the audio file
-    size: usize = GP_FILE_INFO_SIZE, info.size as usize;
+    size: u64 = GP_FILE_INFO_SIZE, info.size;
     /// Mime type of the audio
     mime_type: Cow<str> = GP_FILE_INFO_TYPE, char_slice_to_cow(&info.type_);
   }
@@ -238,11 +240,11 @@ storage_info!(
     /// Access permissions
     access_type: AccessType = GP_STORAGEINFO_ACCESS, info.access.into();
     /// Total storage capacity in Kilobytes
-    capacity_kb: usize = GP_STORAGEINFO_MAXCAPACITY, info.capacitykbytes as usize * 1024;
+    capacity_kb: u64 = GP_STORAGEINFO_MAXCAPACITY, info.capacitykbytes * 1024;
     /// Free storage in Kilobytes
-    free_kb: usize = GP_STORAGEINFO_FREESPACEKBYTES, info.freekbytes as usize * 1024;
+    free_kb: u64 = GP_STORAGEINFO_FREESPACEKBYTES, info.freekbytes * 1024;
     /// Number of images that fit in free space (guessed by the camera)
-    free_images: usize = GP_STORAGEINFO_FREESPACEIMAGES, info.freeimages as usize;
+    free_images: u64 = GP_STORAGEINFO_FREESPACEIMAGES, info.freeimages;
   }
 );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(unused_must_use)]
 #![deny(missing_docs)] // Force documentation on all public API's
+#![deny(clippy::as_conversions)]
 
 pub mod abilities;
 pub mod camera;


### PR DESCRIPTION
Doing ` as usize` everywhere is dangerous, especially when it's converting from e.g. 64-bit value on 32-bit platform and so on. In other cases it might be inefficient (e.g. promoting 32-bit value to 64 bits for no reason).

Instead, it's better to keep original integer type where possible, and use `usize` only for collection lengths, and even there use `try_into()` for checked conversion.

USB fields have well-defined value ranges that libgphoto2 for some reason ignores and represents as `int`, so here we can downcast ourselves.