### PR TITLE
Lock a global mutext whenever libtool is called

### DIFF
--- a/src/abilities.rs
+++ b/src/abilities.rs
@@ -2,7 +2,7 @@
 //!
 //! The device abilities describe the abilities of the driver used to connect to a device.
 
-use crate::helper::{as_ref, bitflags, char_slice_to_cow};
+use crate::helper::{as_ref, bitflags, char_slice_to_cow, libtool_lock};
 use crate::{context::Context, try_gp_internal, Result};
 use std::{borrow::Cow, fmt};
 
@@ -113,6 +113,8 @@ as_ref!(Abilities -> libgphoto2_sys::CameraAbilities, self.inner);
 
 impl AbilitiesList {
   pub(crate) fn new(context: &Context) -> Result<Self> {
+    let _lock = libtool_lock(); // gp_abilities_list_load -> libtool
+
     try_gp_internal!(gp_abilities_list_new(&out abilities_inner)?);
     try_gp_internal!(gp_abilities_list_load(abilities_inner, context.inner)?);
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -4,7 +4,7 @@ use crate::{
   abilities::Abilities,
   file::{CameraFile, CameraFilePath},
   filesys::{CameraFS, StorageInfo},
-  helper::{as_ref, char_slice_to_cow, chars_to_string, to_c_string, UninitBox},
+  helper::{as_ref, char_slice_to_cow, chars_to_string, to_c_string, UninitBox, libtool_lock},
   port::PortInfo,
   try_gp_internal,
   widget::{GroupWidget, Widget, WidgetBase},
@@ -86,6 +86,9 @@ pub struct Camera {
 
 impl Drop for Camera {
   fn drop(&mut self) {
+    // gp_camera_unref -> gp_camera_free -> gp_camera_exit -> libtool
+    let _lock = libtool_lock();
+
     unsafe {
       libgphoto2_sys::gp_camera_unref(self.camera);
       libgphoto2_sys::gp_context_unref(self.context);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 //! Library context
-use crate::helper::{as_ref, to_c_string};
+use crate::helper::{as_ref, to_c_string, libtool_lock};
 use crate::list::{CameraDescriptor, CameraListIter};
 use crate::{
   abilities::AbilitiesList, camera::Camera, list::CameraList, port::PortInfoList, try_gp_internal,
@@ -55,8 +55,10 @@ impl Context {
   /// Returns a list of (camera_name, port_path)
   /// which can be used in [`Context::get_camera`].
   pub fn list_cameras(&self) -> Result<CameraListIter> {
+    // gp_camera_autodetect -> (gp_port_info_list_load, gp_abilities_list_load, ...) -> libtool
+    let _lock = libtool_lock();
+    
     let camera_list = CameraList::new()?;
-
     try_gp_internal!(gp_camera_autodetect(camera_list.inner, self.inner)?);
 
     Ok(CameraListIter::new(camera_list))
@@ -78,6 +80,8 @@ impl Context {
   /// # }
   /// ```
   pub fn autodetect_camera(&self) -> Result<Camera> {
+    let _lock = libtool_lock(); // gp_camera_init -> libtool
+
     try_gp_internal!(gp_camera_new(&out camera_ptr)?);
     try_gp_internal!(gp_camera_init(camera_ptr, self.inner)?);
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,5 +1,8 @@
 use std::mem::MaybeUninit;
+use std::sync::{Mutex, MutexGuard};
 use std::{borrow::Cow, ffi, os::raw::c_char};
+
+static LIBTOOL_LOCK: Mutex<()> = Mutex::new(());
 
 pub fn char_slice_to_cow(chars: &[c_char]) -> Cow<'_, str> {
   unsafe { String::from_utf8_lossy(ffi::CStr::from_ptr(chars.as_ptr()).to_bytes()) }
@@ -7,6 +10,13 @@ pub fn char_slice_to_cow(chars: &[c_char]) -> Cow<'_, str> {
 
 pub fn chars_to_string(chars: *const c_char) -> String {
   unsafe { String::from_utf8_lossy(ffi::CStr::from_ptr(chars).to_bytes()) }.into_owned()
+}
+
+pub fn libtool_lock() -> MutexGuard<'static, ()> {
+  match LIBTOOL_LOCK.lock() {
+    Ok(guard) => guard,
+    Err(err) => err.into_inner()
+  }
 }
 
 pub struct UninitBox<T> {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -15,7 +15,8 @@ pub fn chars_to_string(chars: *const c_char) -> String {
 pub fn libtool_lock() -> MutexGuard<'static, ()> {
   match LIBTOOL_LOCK.lock() {
     Ok(guard) => guard,
-    Err(err) => err.into_inner()
+    // Since the lock contains no meaningful data, if the Mutex got poisoned there is no need for other threads to panic
+    Err(err) => err.into_inner(),
   }
 }
 

--- a/src/port.rs
+++ b/src/port.rs
@@ -17,7 +17,7 @@
 //! ```
 
 use crate::{
-  helper::{as_ref, chars_to_string},
+  helper::{as_ref, chars_to_string, libtool_lock},
   try_gp_internal, Result,
 };
 use std::fmt;
@@ -129,6 +129,8 @@ impl PortInfo {
 
 impl PortInfoList {
   pub(crate) fn new() -> Result<Self> {
+    let _lock = libtool_lock(); // gp_port_info_list_load -> libtool
+
     try_gp_internal!(gp_port_info_list_new(&out port_info_list)?);
     try_gp_internal!(gp_port_info_list_load(port_info_list)?);
 


### PR DESCRIPTION
`libgphoto2` uses libgphoto2 which is not thread safe, to fix I added a global Mutex which is locked whenever a libgphoto2 function is called that internally calls libtool.

fixes #22

cc @RReverser