### PR TITLE
Hook up logging facilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ members = ["libgphoto2-sys"]
 [dependencies]
 libgphoto2_sys = { path = "libgphoto2-sys", version = "1.1" }
 libc = "0.2"
+log = "0.4"
+
+[dev-dependencies]
+env_logger = "0.9.1"

--- a/examples/bulb_capture.rs
+++ b/examples/bulb_capture.rs
@@ -8,6 +8,8 @@ use gphoto2::{camera::CameraEvent, Context, Result};
 use std::{thread::sleep, time::Duration};
 
 fn main() -> Result<()> {
+  env_logger::init();
+
   let camera = Context::new()?.autodetect_camera()?;
 
   let shutter_speed = camera.config_key::<RadioWidget>("shutterspeed")?;

--- a/examples/camera_info.rs
+++ b/examples/camera_info.rs
@@ -1,6 +1,8 @@
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
+  env_logger::init();
+
   let camera = Context::new()?.autodetect_camera()?;
 
   println!("==== SUMMARY   ====\n{}", camera.summary()?);

--- a/examples/capture.rs
+++ b/examples/capture.rs
@@ -2,6 +2,8 @@ use gphoto2::{Context, Result};
 use std::path::Path;
 
 fn main() -> Result<()> {
+  env_logger::init();
+
   let camera = Context::new()?.autodetect_camera()?;
 
   let file = camera.capture_image()?;

--- a/examples/capture_preview.rs
+++ b/examples/capture_preview.rs
@@ -4,6 +4,8 @@ use gphoto2::{Context, Result};
 use std::{fs, io::Write};
 
 fn main() -> Result<()> {
+  env_logger::init();
+
   let camera = Context::new()?.autodetect_camera()?;
 
   let mut file = fs::File::create("/tmp/preview_image")?;

--- a/examples/drop_camera.rs
+++ b/examples/drop_camera.rs
@@ -3,6 +3,8 @@
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
+  env_logger::init();
+
   let camera = Context::new()?.autodetect_camera()?;
 
   let widget = camera.config()?;

--- a/examples/list_cameras.rs
+++ b/examples/list_cameras.rs
@@ -2,6 +2,8 @@ use gphoto2::list::CameraDescriptor;
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
+  env_logger::init();
+
   let context = Context::new()?;
 
   println!("Available cameras:");

--- a/examples/list_config.rs
+++ b/examples/list_config.rs
@@ -4,6 +4,8 @@
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
+  env_logger::init();
+
   let camera = Context::new()?.autodetect_camera()?;
   println!("{:#?}", camera.config()?);
   Ok(())

--- a/examples/opcode.rs
+++ b/examples/opcode.rs
@@ -9,6 +9,8 @@ use gphoto2::{Context, Result};
 use std::{thread, time::Duration};
 
 fn main() -> Result<()> {
+  env_logger::init();
+
   let camera = Context::new()?.autodetect_camera()?;
 
   let opcode = camera.config_key::<TextWidget>("opcode")?;

--- a/examples/select_camera.rs
+++ b/examples/select_camera.rs
@@ -5,6 +5,8 @@
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
+  env_logger::init();
+
   let camera_name = std::env::args().nth(1).expect("Missing argument: camera_model");
 
   let context = Context::new()?;

--- a/src/context.rs
+++ b/src/context.rs
@@ -53,7 +53,7 @@ impl Context {
       log_level_as_ptr: *mut libc::c_void,
     ) {
       let log_level: log::Level = std::mem::transmute(log_level_as_ptr);
-      log::log!(log_level, "{}", chars_to_string(text));
+      log::log!(target: "gphoto2", log_level, "{}", chars_to_string(text));
     }
 
     unsafe {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 //! Library context
-use crate::helper::{as_ref, libtool_lock, to_c_string};
+use crate::helper::{as_ref, chars_to_string, libtool_lock, to_c_string};
 use crate::list::{CameraDescriptor, CameraListIter};
 use crate::{
   abilities::AbilitiesList, camera::Camera, list::CameraList, port::PortInfoList, try_gp_internal,
@@ -44,10 +44,38 @@ impl Context {
     let context_ptr = unsafe { libgphoto2_sys::gp_context_new() };
 
     if context_ptr.is_null() {
-      Err(Error::new(libgphoto2_sys::GP_ERROR_NO_MEMORY, None))
-    } else {
-      Ok(Self { inner: context_ptr })
+      return Err(Error::new(libgphoto2_sys::GP_ERROR_NO_MEMORY, None));
     }
+
+    unsafe extern "C" fn log_func(
+      _context: *mut libgphoto2_sys::GPContext,
+      text: *const libc::c_char,
+      log_level_as_ptr: *mut libc::c_void,
+    ) {
+      let log_level: log::Level = std::mem::transmute(log_level_as_ptr);
+      log::log!(log_level, "{}", chars_to_string(text));
+    }
+
+    unsafe {
+      if log::log_enabled!(log::Level::Error) {
+        let log_level_as_ptr = std::mem::transmute(log::Level::Error);
+
+        libgphoto2_sys::gp_context_set_error_func(context_ptr, Some(log_func), log_level_as_ptr);
+
+        // `gp_context_message` seems to be used also for error messages.
+        libgphoto2_sys::gp_context_set_message_func(context_ptr, Some(log_func), log_level_as_ptr);
+      }
+
+      if log::log_enabled!(log::Level::Info) {
+        libgphoto2_sys::gp_context_set_status_func(
+          context_ptr,
+          Some(log_func),
+          std::mem::transmute(log::Level::Info),
+        );
+      }
+    }
+
+    Ok(Self { inner: context_ptr })
   }
 
   /// Lists all available cameras and their ports


### PR DESCRIPTION
Hooks up libgphoto2's logging to Rust log crate, so that downstream users have easier time debugging various errors.

Example:

```
> RUST_LOG=gphoto2=error cargo run --example capture_preview
   Compiling gphoto2 v1.5.0 (/mnt/c/Users/me/Documents/gphoto2-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 18.29s
     Running `target/debug/examples/capture_preview`
[2022-09-24T14:23:07Z ERROR gphoto2::context] Sorry, your Nikon camera does not support LiveView mode
Error: Unsupported operation
```