### PR TITLE
Expose IO_USB_CLAIM error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,8 @@ pub enum ErrorKind {
   Timeout,
   /// Port is not known
   UnknownPort,
+  /// Couldn't claim USB device.
+  IoUsbClaim,
 }
 
 /// General error
@@ -93,6 +95,7 @@ impl Error {
       libgphoto2_sys::GP_ERROR_PATH_NOT_ABSOLUTE => ErrorKind::PathNotAbsolute,
       libgphoto2_sys::GP_ERROR_TIMEOUT => ErrorKind::Timeout,
       libgphoto2_sys::GP_ERROR_UNKNOWN_PORT => ErrorKind::UnknownPort,
+      libgphoto2_sys::GP_ERROR_IO_USB_CLAIM => ErrorKind::IoUsbClaim,
 
       libgphoto2_sys::GP_ERROR => ErrorKind::Other,
       _ => ErrorKind::Other,


### PR DESCRIPTION
This error is important because it allow the application to try to solve it. I have crude code to for example unmount from gvfs.