### PR TITLE
Make Context and Camera : Sync

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -378,6 +378,12 @@ impl Camera {
 
 #[cfg(all(test, feature = "test"))]
 mod tests {
+  // Compile-only test to ensure that Camera is Send + Sync.
+  const _: () = {
+    const fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<super::Camera>()
+  };
+
   fn sample_camera() -> super::Camera {
     crate::sample_context().autodetect_camera().wait().unwrap()
   }

--- a/src/file.rs
+++ b/src/file.rs
@@ -75,13 +75,14 @@ impl From<libgphoto2_sys::CameraFileType> for FileType {
 #[cfg(feature = "serde")]
 impl serde::Serialize for CameraFilePath {
   fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-      where
-          S: serde::Serializer {
-      let mut m = serializer.serialize_map(Some(2))?;
-      m.serialize_entry("name", &self.name())?;
-      m.serialize_entry("folder", &self.folder())?;
+  where
+    S: serde::Serializer,
+  {
+    let mut m = serializer.serialize_map(Some(2))?;
+    m.serialize_entry("name", &self.name())?;
+    m.serialize_entry("folder", &self.folder())?;
 
-      m.end()
+    m.end()
   }
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -29,7 +29,7 @@ pub struct Task<T> {
   waker_set: bool,
   task: ToBeRunTask<T>,
   context: Option<BackgroundPtr<libgphoto2_sys::GPContext>>,
-  progress_handler: Option<Box<dyn ProgressHandler + Send>>,
+  progress_handler: Option<Box<dyn ProgressHandler>>,
   recv_waker: Option<Receiver<Waker>>,
 }
 
@@ -118,7 +118,7 @@ where
   /// Must be called before the task is started
   pub fn set_progress_handler<H>(&mut self, handler: H)
   where
-    H: ProgressHandler + Send,
+    H: ProgressHandler,
   {
     self.progress_handler = Some(Box::new(handler));
   }


### PR DESCRIPTION
Fixes #55 by wrapping the handlers into a Mutex. This makes Context and Camera safe to access from arbitrary threads for read-only access.