### PR TITLE
Update bindgen to build with clang 16

### DIFF
--- a/libgphoto2-sys/Cargo.toml
+++ b/libgphoto2-sys/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [build-dependencies]
 pkg-config = "0.3.25"
-bindgen = "0.60.1"
+bindgen = "0.65.1"
 gphoto2_test = { path = "../gphoto2-test", version = "1.0", optional = true }
 
 [dependencies]


### PR DESCRIPTION
- This grab the fix for https://github.com/rust-lang/rust-bindgen/issues/2312

Without that fix the crate `libgphoto2-sys` doesn't build with clang16.

A new release of the -sys crate is likely a good idea.