### PR TITLE
Migrate from logging to tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [features]
 # Uses gp_log_add_func instead of gp_context_set_log_func for logging (not supported on many systems)
 extended_logs = []
-test = ["libgphoto2_sys/test"]
+test = ["libgphoto2_sys/test", "dep:tracing-subscriber"]
 serde = ["dep:serde"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -25,10 +25,10 @@ members = ["libgphoto2-sys", "gphoto2-test"]
 [dependencies]
 libgphoto2_sys = { path = "libgphoto2-sys", version = "1.2" }
 libc = "0.2"
-log = "0.4"
 crossbeam-channel = "0.5.6"
 serde = { version = "1", optional = true, features = ["derive"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", optional = true, features = ["env-filter"] }
 
 [dev-dependencies]
-env_logger = "0.9.1"
 insta = "1.20.0"

--- a/examples/bulb_capture.rs
+++ b/examples/bulb_capture.rs
@@ -3,12 +3,14 @@
 //! There are also actions for capturing movies, changing liveview, etc.  
 //! This example will only work for Nikon DSLR cameras.
 
+mod logging;
+
 use gphoto2::widget::{RadioWidget, ToggleWidget};
 use gphoto2::{camera::CameraEvent, Context, Result};
 use std::{thread::sleep, time::Duration};
 
 fn main() -> Result<()> {
-  env_logger::init();
+  logging::setup();
 
   let camera = Context::new()?.autodetect_camera().wait()?;
 

--- a/examples/camera_info.rs
+++ b/examples/camera_info.rs
@@ -1,7 +1,9 @@
+mod logging;
+
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
-  env_logger::init();
+  logging::setup();
 
   let camera = Context::new()?.autodetect_camera().wait()?;
 

--- a/examples/camera_ls.rs
+++ b/examples/camera_ls.rs
@@ -1,3 +1,5 @@
+mod logging;
+
 use gphoto2::{filesys::CameraFS, Context, Result};
 use std::collections::HashMap;
 
@@ -24,7 +26,7 @@ fn list_folder_recursive(fs: &CameraFS, folder_name: &str) -> Result<FolderConte
 }
 
 fn main() -> Result<()> {
-  env_logger::init();
+  logging::setup();
 
   let camera = Context::new()?.autodetect_camera().wait()?;
   let fs = camera.fs();

--- a/examples/camera_progress.rs
+++ b/examples/camera_progress.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)] // This is just an example
 
+mod logging;
+
 use gphoto2::{Context, Result};
 use std::{collections::HashMap, path::Path};
 
@@ -60,7 +62,7 @@ impl ContextProgress {
 fn main() -> Result<()> {
   let mut context = Context::new()?;
 
-  env_logger::init();
+  logging::setup();
 
   context.set_progress_handlers(ProgressManager::new());
 

--- a/examples/capture.rs
+++ b/examples/capture.rs
@@ -1,8 +1,10 @@
+mod logging;
+
 use gphoto2::{Context, Result};
 use std::path::Path;
 
 fn main() -> Result<()> {
-  env_logger::init();
+  logging::setup();
 
   let camera = Context::new()?.autodetect_camera().wait()?;
 

--- a/examples/capture_preview.rs
+++ b/examples/capture_preview.rs
@@ -1,10 +1,12 @@
 //! Capture a preview and save it to /tmp/preview_image
 
+mod logging;
+
 use gphoto2::{Context, Result};
 use std::{fs, io::Write};
 
 fn main() -> Result<()> {
-  env_logger::init();
+  logging::setup();
 
   let context = Context::new()?;
   let camera = context.autodetect_camera().wait()?;

--- a/examples/drop_camera.rs
+++ b/examples/drop_camera.rs
@@ -1,9 +1,11 @@
 //! Test if the camera can be dropped while there are is still eg. a widget of that camera present
 
+mod logging;
+
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
-  env_logger::init();
+  logging::setup();
 
   let camera = Context::new()?.autodetect_camera().wait()?;
 

--- a/examples/list_cameras.rs
+++ b/examples/list_cameras.rs
@@ -1,8 +1,10 @@
+mod logging;
+
 use gphoto2::list::CameraDescriptor;
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
-  env_logger::init();
+  logging::setup();
 
   let context = Context::new()?;
 

--- a/examples/list_config.rs
+++ b/examples/list_config.rs
@@ -1,10 +1,12 @@
 //! Recursively list all configuration
 //! Warning: Output might be very large
 
+mod logging;
+
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
-  env_logger::init();
+  logging::setup();
 
   let camera = Context::new()?.autodetect_camera().wait()?;
   println!("{:#?}", camera.config().wait()?);

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,0 +1,13 @@
+use tracing_subscriber::{prelude::*, EnvFilter};
+
+pub fn setup() {
+  tracing_subscriber::registry()
+    .with(EnvFilter::from_default_env())
+    .with(tracing_subscriber::fmt::layer())
+    .init();
+}
+
+#[allow(dead_code)]
+fn main() {
+  eprintln!("This is only a library file")
+}

--- a/examples/opcode.rs
+++ b/examples/opcode.rs
@@ -4,12 +4,14 @@
 //! This example starts and ends live view mode on the camera for 10 s,
 //! this example only works on Nikon cameras.
 
+mod logging;
+
 use gphoto2::widget::TextWidget;
 use gphoto2::{Context, Result};
 use std::{thread, time::Duration};
 
 fn main() -> Result<()> {
-  env_logger::init();
+  logging::setup();
 
   let camera = Context::new()?.autodetect_camera().wait()?;
 

--- a/examples/select_camera.rs
+++ b/examples/select_camera.rs
@@ -2,10 +2,12 @@
 //! Usage: select_camera <camera_name>
 //! To get a list of connected cameras, run example list_cameras
 
+mod logging;
+
 use gphoto2::{Context, Result};
 
 fn main() -> Result<()> {
-  env_logger::init();
+  logging::setup();
 
   let camera_name = std::env::args().nth(1).expect("Missing argument: camera_model");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,15 +36,13 @@ compile_error!("The test feature must be enabled to run the tests");
 #[cfg(all(test, feature = "test"))]
 fn sample_context() -> Context {
   use std::sync::Once;
+  use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
   static INIT: Once = Once::new();
   INIT.call_once(|| {
-    // Enable logging.
-    env_logger::builder()
-      // As much logging as possible.
-      .filter_module("gphoto2", log::LevelFilter::max())
-      // But hide logs if tests are successful.
-      .is_test(true)
+    tracing_subscriber::registry()
+      .with(fmt::layer())
+      .with(EnvFilter::from_default_env().add_directive("gphoto2=trace".parse().unwrap()))
       .init();
 
     // Tell libgphoto2 to look for drivers in a custom built directory.


### PR DESCRIPTION
There currently are some limitations by the tracing framework, most notably tokio-rs/tracing#372 which doesn't allow the creation of events that have a level or target set at runtime.