### PR TITLE
Add access to gp_library_version function

### DIFF
--- a/libgphoto2-sys/src/wrapper.h
+++ b/libgphoto2-sys/src/wrapper.h
@@ -1,1 +1,2 @@
 #include <gphoto2/gphoto2.h>
+#include <gphoto2/gphoto2-version.h>


### PR DESCRIPTION
Usage example:

```
use ::gphoto2::libgphoto2_sys::{gp_library_version, GPVersionVerbosity};

pub fn get_version_info() -> String {
    // Returns "2.5.31" as of now if latest stable is available
    unsafe {
        CStr::from_ptr(*gp_library_version(GPVersionVerbosity::GP_VERSION_SHORT))
    }.to_string_lossy().into_owned()
}
```
